### PR TITLE
BST-48482 Page submissionDraftSaved.scala.html. Restored /logout endpoint.

### DIFF
--- a/app/controllers/LoginController.scala
+++ b/app/controllers/LoginController.scala
@@ -91,14 +91,13 @@ class LoginController @Inject() (
     Future.successful(Ok(login(loginForm)))
   }
 
-  def logout(implicit hc: HeaderCarrier) = (Action andThen withSessionRefiner).async { implicit request =>
+  def logout = (Action andThen withSessionRefiner).async { implicit request =>
     val refNumJson = Json.obj(Audit.referenceNumber -> request.sessionData.userLoginDetails.referenceNumber)
 
     session.remove().map { _ =>
       audit.sendExplicitAudit("Logout", refNumJson)
       Redirect(routes.LoginController.show())
     }
-
   }
 
   def submit = Action.async { implicit request =>

--- a/app/util/DateUtil.scala
+++ b/app/util/DateUtil.scala
@@ -54,7 +54,4 @@ class DateUtil @Inject() (langUtil: LanguageUtils) {
   def formatDate(date: LocalDate)(implicit messages: Messages): String =
     langUtil.Dates.formatDate(date)
 
-  def formatDate(date: ZonedDateTime)(implicit messages: Messages): String =
-    formatDate(date.toLocalDate)
-
 }

--- a/app/views/submissionDraftSaved.scala.html
+++ b/app/views/submissionDraftSaved.scala.html
@@ -1,0 +1,74 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukButton, GovukPanel, GovukWarningText}
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.warningtext.WarningText
+
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        govukPanel: GovukPanel,
+        govukWarningText: GovukWarningText
+)
+
+@(password: String, expiryDate: String, exitPath: String, isTimedOut: Boolean = false)(implicit request: Request[_], messages: Messages)
+
+@title = @{
+    if(isTimedOut) {
+        messages("saveAsDraft.preHeaderTimeout")
+    } else {
+        messages("saveAsDraft.preHeader")
+    }
+}
+
+@layout(
+    pageHeading = title,
+    showH1 = false,
+    withTimeoutDialog = false
+) {
+
+    <h1 class="govuk-heading-l">@title</h1>
+
+    @govukWarningText(
+        WarningText(
+            content = Text(messages("saveAsDraft.info"))
+        )
+    )
+
+    <p class="govuk-body">@messages("saveAsDraft.info.p.2")</p>
+
+    <div class="govuk-panel govuk-panel--confirmation">
+        <div class="govuk-panel__body">
+            <span>@messages("saveAsDraft.password"):</span> <strong>@password</strong>
+        </div>
+    </div>
+
+    <p class="govuk-body">
+        @messages("saveAsDraft.paragraph") @expiryDate
+    </p>
+
+    <p class="govuk-body">
+    @if(isTimedOut) {
+        <a class="govuk-button" href=@routes.LoginController.show>@messages("sessionTimeout.button")</a>
+    } else {
+        <a href="@exitPath" class="govuk-button">@messages("saveAsDraft.continue")</a>
+        <a href="@routes.LoginController.logout" class="govuk-button">@messages("saveAsDraft.logout")</a>
+    }
+    </p>
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -10,6 +10,7 @@ GET         /login                                                  controllers.
 POST        /login                                                  controllers.LoginController.submit()
 GET         /$count<\d>-sign-in-attempts-remaining                  controllers.LoginController.loginFailed(count: Int)
 GET         /lockedout                                              controllers.LoginController.lockedOut
+GET         /logout                                                 controllers.LoginController.logout
 
 GET         /invalid-form-type                                      controllers.LoginController.notValidFORType()
 

--- a/conf/messages
+++ b/conf/messages
@@ -705,6 +705,8 @@ saveAsDraft.validPassword=Password must be at least 7 characters.
 saveAsDraft.error.passwordsDontMatch=Passwords do not match
 saveAsDraft.createPassword.header=Create a password to retrieve your saved information
 saveAsDraft.next=Save password
+saveAsDraft.continue=Continue completing this form
+saveAsDraft.logout=Log out
 
 # Errors
 ########

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -17,7 +17,7 @@ hintText.optional = (opsiynol)
 ##############################
 heading.sessionTimeout=Session timed out
 sessionTimeout.copy=You have been logged out as you have not used this form for the last 24 hours.
-sessionTimeout.button=Please log in again
+sessionTimeout.button=Mewngofnodwch eto
 
 #WELSH YES/NO
 #############
@@ -705,7 +705,8 @@ saveAsDraft.validPassword=Rhaid i’r cyfrinair fod o leiaf 7 nod yn hir.
 saveAsDraft.error.passwordsDontMatch=Nid yw’r cyfrineiriau yn cyfateb.
 saveAsDraft.createPassword.header=Creu cyfrinair i adfer eich gwybodaeth
 saveAsDraft.next=Cadw cyfrinair
-
+saveAsDraft.continue=Parhewch i lenwi'r ffurflen hon
+saveAsDraft.logout=Allgofnodi
 
 # Errors
 ########

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -24,7 +24,7 @@ object CodeCoverageSettings {
 
   val settings: Seq[Setting[_]] = Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
-    ScoverageKeys.coverageMinimumStmtTotal := 68,
+    ScoverageKeys.coverageMinimumStmtTotal := 70,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )

--- a/test/controllers/LoginControllerSpec.scala
+++ b/test/controllers/LoginControllerSpec.scala
@@ -19,7 +19,6 @@ package controllers
 import config.LoginToBackendAction
 import connectors.Audit
 import org.joda.time.DateTime
-import play.api.i18n.Lang
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers._

--- a/test/controllers/LoginControllerSpec.scala
+++ b/test/controllers/LoginControllerSpec.scala
@@ -61,7 +61,7 @@ class LoginControllerSpec extends TestBaseSpec {
         inject[views.html.testSign]
       )
 
-      val result = loginController.show(fakeRequest.withTransientLang(Lang("en")))
+      val result = loginController.show(fakeRequest)
 
       status(result) shouldBe OK
 

--- a/test/controllers/SaveAsDraftControllerSpec.scala
+++ b/test/controllers/SaveAsDraftControllerSpec.scala
@@ -19,12 +19,13 @@ package controllers
 import actions.WithSessionRefiner
 import config.ErrorHandler
 import connectors.Audit
-import play.api.http.Status.OK
+import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.test.Helpers.{POST, contentAsString, status, stubMessagesControllerComponents}
 import stub.{StubBackendConnector, StubSessionRepo}
 import util.DateUtil
 import utils.TestBaseSpec
 import views.html.customPasswordSaveAsDraft
+import views.html.submissionDraftSaved
 
 /**
   * @author Yuriy Tumakha
@@ -39,6 +40,7 @@ class SaveAsDraftControllerSpec extends TestBaseSpec {
   private def saveAsDraftController = new SaveAsDraftController(
     backendConnector,
     inject[customPasswordSaveAsDraft],
+    inject[submissionDraftSaved],
     inject[DateUtil],
     WithSessionRefiner(inject[ErrorHandler], sessionRepo),
     sessionRepo,
@@ -47,6 +49,13 @@ class SaveAsDraftControllerSpec extends TestBaseSpec {
   )
 
   "SaveAsDraftController.customPassword" should {
+    "return 404 if session is empty" in {
+      sessionRepo.remove()
+
+      val result = saveAsDraftController.customPassword(exitPath)(fakeRequest)
+      status(result) shouldBe NOT_FOUND
+    }
+
     "return customUserPasswordForm if session.saveAsDraftPassword is empty" in {
       sessionRepo.saveOrUpdate(prefilledBaseSession.copy(saveAsDraftPassword = None))
 


### PR DESCRIPTION
- Page `submissionDraftSaved.scala.html`
- Restored `/logout` endpoint
- Test coverage min 70%