### PR TITLE
BST-46989 Send to Splunk audit event `SavedAsDraftEvent` with `UserData`

### DIFF
--- a/app/connectors/Audit.scala
+++ b/app/connectors/Audit.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import com.google.inject.ImplementedBy
-import models.SubmissionDraft
+import models.audit.SavedAsDraftEvent
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -36,11 +36,11 @@ trait Audit extends AuditConnector {
 
   private val AUDIT_SOURCE = "tenure-cost-and-trade-records-frontend"
 
-  def sendContinueNextPage(url: String)(implicit hc: HeaderCarrier): Unit                  =
+  def sendContinueNextPage(url: String)(implicit hc: HeaderCarrier): Unit                      =
     sendEventMap("ContinueNextPage", Map("url" -> url), hc.toAuditTags())
 
-  def sendSavedAsDraft(submissionDraft: SubmissionDraft)(implicit hc: HeaderCarrier): Unit =
-    sendExplicitAudit("SavedAsDraft", submissionDraft)
+  def sendSavedAsDraft(savedAsDraftEvent: SavedAsDraftEvent)(implicit hc: HeaderCarrier): Unit =
+    sendExplicitAudit("SavedAsDraft", savedAsDraftEvent)
 
   private def sendEventMap(event: String, detail: Map[String, String], tags: Map[String, String])(implicit
     hc: HeaderCarrier

--- a/app/controllers/SaveAsDraftController.scala
+++ b/app/controllers/SaveAsDraftController.scala
@@ -85,7 +85,7 @@ class SaveAsDraftController @Inject() (
     val submissionDraft = SubmissionDraft(forType, session, exitPath)
 
     backendConnector.saveAsDraft(referenceNumber, submissionDraft).map { _ =>
-      audit.sendSavedAsDraft(submissionDraft)
+      audit.sendSavedAsDraft(submissionDraft.toSavedAsDraftEvent)
       Ok(submissionDraftSavedView(session.saveAsDraftPassword.getOrElse(""), expiryDate, exitPath))
     }
   }

--- a/app/models/Session.scala
+++ b/app/models/Session.scala
@@ -16,6 +16,7 @@
 
 package models
 
+import models.audit.UserData
 import models.submissions.aboutYourLeaseOrTenure.{AboutLeaseOrAgreementPartOne, AboutLeaseOrAgreementPartTwo}
 import models.submissions.aboutfranchisesorlettings.AboutFranchisesOrLettings
 import models.submissions.abouttheproperty.AboutTheProperty
@@ -27,6 +28,7 @@ import models.submissions.connectiontoproperty.StillConnectedDetails
 import models.submissions.notconnected.RemoveConnectionDetails
 import play.api.libs.json._
 
+// New session properties must be also added to class `UserData` and method `toUserData`
 case class Session(
   referenceNumber: String,
   forType: String,
@@ -42,7 +44,25 @@ case class Session(
   aboutLeaseOrAgreementPartOne: Option[AboutLeaseOrAgreementPartOne] = None,
   aboutLeaseOrAgreementPartTwo: Option[AboutLeaseOrAgreementPartTwo] = None,
   saveAsDraftPassword: Option[String] = None
-)
+  // New session properties must be also added to class `UserData` and method `toUserData`
+) {
+
+  def toUserData: UserData = UserData(
+    referenceNumber,
+    forType,
+    address,
+    stillConnectedDetails,
+    removeConnectionDetails,
+    aboutYou,
+    aboutTheProperty,
+    additionalInformation,
+    aboutTheTradingHistory,
+    aboutFranchisesOrLettings,
+    aboutLeaseOrAgreementPartOne,
+    aboutLeaseOrAgreementPartTwo
+  )
+
+}
 
 object Session {
   implicit val format = Json.format[Session]

--- a/app/models/audit/SavedAsDraftEvent.scala
+++ b/app/models/audit/SavedAsDraftEvent.scala
@@ -14,24 +14,19 @@
  * limitations under the License.
  */
 
-package models
+package models.audit
 
-import models.audit.SavedAsDraftEvent
 import play.api.libs.json.{Json, OFormat}
 
 /**
   * @author Yuriy Tumakha
   */
-case class SubmissionDraft(
+case class SavedAsDraftEvent(
   forType: String,
-  session: Session,
+  userData: UserData,
   exitPath: String
-) {
+)
 
-  def toSavedAsDraftEvent: SavedAsDraftEvent = SavedAsDraftEvent(forType, session.toUserData, exitPath)
-
-}
-
-object SubmissionDraft {
-  implicit val format: OFormat[SubmissionDraft] = Json.format[SubmissionDraft]
+object SavedAsDraftEvent {
+  implicit val format: OFormat[SavedAsDraftEvent] = Json.format[SavedAsDraftEvent]
 }

--- a/app/models/audit/UserData.scala
+++ b/app/models/audit/UserData.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.audit
+
+import models.submissions.aboutYourLeaseOrTenure.{AboutLeaseOrAgreementPartOne, AboutLeaseOrAgreementPartTwo}
+import models.submissions.aboutfranchisesorlettings.AboutFranchisesOrLettings
+import models.submissions.abouttheproperty.AboutTheProperty
+import models.submissions.aboutthetradinghistory.AboutTheTradingHistory
+import models.submissions.aboutyou.AboutYou
+import models.submissions.additionalinformation.AdditionalInformation
+import models.submissions.common.Address
+import models.submissions.connectiontoproperty.StillConnectedDetails
+import models.submissions.notconnected.RemoveConnectionDetails
+import play.api.libs.json.{Json, OFormat}
+
+/**
+  * @author Yuriy Tumakha
+  */
+case class UserData(
+  referenceNumber: String,
+  forType: String,
+  address: Address,
+  stillConnectedDetails: Option[StillConnectedDetails],
+  removeConnectionDetails: Option[RemoveConnectionDetails],
+  aboutYou: Option[AboutYou],
+  aboutTheProperty: Option[AboutTheProperty],
+  additionalInformation: Option[AdditionalInformation],
+  aboutTheTradingHistory: Option[AboutTheTradingHistory],
+  aboutFranchisesOrLettings: Option[AboutFranchisesOrLettings],
+  aboutLeaseOrAgreementPartOne: Option[AboutLeaseOrAgreementPartOne],
+  aboutLeaseOrAgreementPartTwo: Option[AboutLeaseOrAgreementPartTwo]
+)
+
+object UserData {
+  implicit val format: OFormat[UserData] = Json.format[UserData]
+}


### PR DESCRIPTION
Send to Splunk `SavedAsDraftEvent` with `UserData` instead of `SubmissionDraft`