### PR TITLE
BST-60557 Add another business page in Franchises or lettings

### DIFF
--- a/app/controllers/aboutfranchisesorlettings/CateringOperationDetailsController.scala
+++ b/app/controllers/aboutfranchisesorlettings/CateringOperationDetailsController.scala
@@ -92,11 +92,11 @@ class CateringOperationDetailsController @Inject() (
           )
         ),
       data => {
-        val ifFranchisesOrLettingsEmpty                                        = AboutFranchisesOrLettings(cateringOperationSections =
+        val ifFranchisesOrLettingsEmpty                                 = AboutFranchisesOrLettings(cateringOperationSections =
           IndexedSeq(CateringOperationSection(cateringOperationDetails = data))
         )
-        val updatedAboutFranchisesOrLettings: (Int, AboutFranchisesOrLettings) =
-          request.sessionData.aboutFranchisesOrLettings.fold(0 -> ifFranchisesOrLettingsEmpty) { franchiseOrLettings =>
+        val updatedAboutFranchisesOrLettings: AboutFranchisesOrLettings =
+          request.sessionData.aboutFranchisesOrLettings.fold(ifFranchisesOrLettingsEmpty) { franchiseOrLettings =>
             val existingSections                                             = franchiseOrLettings.cateringOperationSections
             val requestedSection                                             = index.flatMap(existingSections.lift)
             val updatedSections: (Int, IndexedSeq[CateringOperationSection]) =
@@ -111,15 +111,13 @@ class CateringOperationDetailsController @Inject() (
                   sectionToUpdate.copy(cateringOperationDetails = data)
                 )
               }
-            updatedSections._1 -> franchiseOrLettings
-              .copy(cateringOperationSections = updatedSections._2)
+            franchiseOrLettings
+              .copy(cateringOperationCurrentIndex = updatedSections._1, cateringOperationSections = updatedSections._2)
           }
-        updatedAboutFranchisesOrLettings match {
-          case (currentIndex, aboutFranchisesOrLettings) =>
-            val updatedData = updateAboutFranchisesOrLettings(_ => aboutFranchisesOrLettings)
-            session.saveOrUpdate(updatedData)
-            Redirect(navigator.nextPage(CateringOperationDetailsPageId, updatedData).apply(updatedData))
-        }
+
+        val updatedData = updateAboutFranchisesOrLettings(_ => updatedAboutFranchisesOrLettings)
+        session.saveOrUpdate(updatedData)
+        Redirect(navigator.nextPage(CateringOperationDetailsPageId, updatedData).apply(updatedData))
       }
     )
   }

--- a/app/controllers/aboutfranchisesorlettings/CateringOperationDetailsController.scala
+++ b/app/controllers/aboutfranchisesorlettings/CateringOperationDetailsController.scala
@@ -92,10 +92,10 @@ class CateringOperationDetailsController @Inject() (
           )
         ),
       data => {
-        val ifFranchisesOrLettingsEmpty                                 = AboutFranchisesOrLettings(cateringOperationSections =
+        val ifFranchisesOrLettingsEmpty      = AboutFranchisesOrLettings(cateringOperationSections =
           IndexedSeq(CateringOperationSection(cateringOperationDetails = data))
         )
-        val updatedAboutFranchisesOrLettings: AboutFranchisesOrLettings =
+        val updatedAboutFranchisesOrLettings =
           request.sessionData.aboutFranchisesOrLettings.fold(ifFranchisesOrLettingsEmpty) { franchiseOrLettings =>
             val existingSections                                             = franchiseOrLettings.cateringOperationSections
             val requestedSection                                             = index.flatMap(existingSections.lift)

--- a/app/controllers/aboutfranchisesorlettings/LettingOtherPartOfPropertyDetailsController.scala
+++ b/app/controllers/aboutfranchisesorlettings/LettingOtherPartOfPropertyDetailsController.scala
@@ -73,11 +73,11 @@ class LettingOtherPartOfPropertyDetailsController @Inject() (
           )
         ),
       data => {
-        val ifFranchisesOrLettingsEmpty                                        = AboutFranchisesOrLettings(lettingSections =
+        val ifFranchisesOrLettingsEmpty                                 = AboutFranchisesOrLettings(lettingSections =
           IndexedSeq(LettingSection(lettingOtherPartOfPropertyInformationDetails = data))
         )
-        val updatedAboutFranchisesOrLettings: (Int, AboutFranchisesOrLettings) =
-          request.sessionData.aboutFranchisesOrLettings.fold(0 -> ifFranchisesOrLettingsEmpty) { franchiseOrLettings =>
+        val updatedAboutFranchisesOrLettings: AboutFranchisesOrLettings =
+          request.sessionData.aboutFranchisesOrLettings.fold(ifFranchisesOrLettingsEmpty) { franchiseOrLettings =>
             val existingSections                                   = franchiseOrLettings.lettingSections
             val requestedSection                                   = index.flatMap(existingSections.lift)
             val updatedSections: (Int, IndexedSeq[LettingSection]) = requestedSection.fold {
@@ -89,14 +89,12 @@ class LettingOtherPartOfPropertyDetailsController @Inject() (
               indexToUpdate -> existingSections
                 .updated(indexToUpdate, sectionToUpdate.copy(lettingOtherPartOfPropertyInformationDetails = data))
             }
-            updatedSections._1 -> franchiseOrLettings.copy(lettingSections = updatedSections._2)
+            franchiseOrLettings
+              .copy(lettingCurrentIndex = updatedSections._1, lettingSections = updatedSections._2)
           }
-        updatedAboutFranchisesOrLettings match {
-          case (currentIndex, aboutFranchisesOrLettings) =>
-            val updatedData = updateAboutFranchisesOrLettings(_ => aboutFranchisesOrLettings)
-            session.saveOrUpdate(updatedData)
-            Redirect(navigator.nextPage(LettingAccommodationDetailsPageId, updatedData).apply(updatedData))
-        }
+        val updatedData                                                 = updateAboutFranchisesOrLettings(_ => updatedAboutFranchisesOrLettings)
+        session.saveOrUpdate(updatedData)
+        Redirect(navigator.nextPage(LettingAccommodationDetailsPageId, updatedData).apply(updatedData))
       }
     )
   }

--- a/app/controllers/aboutfranchisesorlettings/LettingOtherPartOfPropertyDetailsController.scala
+++ b/app/controllers/aboutfranchisesorlettings/LettingOtherPartOfPropertyDetailsController.scala
@@ -73,10 +73,10 @@ class LettingOtherPartOfPropertyDetailsController @Inject() (
           )
         ),
       data => {
-        val ifFranchisesOrLettingsEmpty                                 = AboutFranchisesOrLettings(lettingSections =
+        val ifFranchisesOrLettingsEmpty      = AboutFranchisesOrLettings(lettingSections =
           IndexedSeq(LettingSection(lettingOtherPartOfPropertyInformationDetails = data))
         )
-        val updatedAboutFranchisesOrLettings: AboutFranchisesOrLettings =
+        val updatedAboutFranchisesOrLettings =
           request.sessionData.aboutFranchisesOrLettings.fold(ifFranchisesOrLettingsEmpty) { franchiseOrLettings =>
             val existingSections                                   = franchiseOrLettings.lettingSections
             val requestedSection                                   = index.flatMap(existingSections.lift)
@@ -92,7 +92,7 @@ class LettingOtherPartOfPropertyDetailsController @Inject() (
             franchiseOrLettings
               .copy(lettingCurrentIndex = updatedSections._1, lettingSections = updatedSections._2)
           }
-        val updatedData                                                 = updateAboutFranchisesOrLettings(_ => updatedAboutFranchisesOrLettings)
+        val updatedData                      = updateAboutFranchisesOrLettings(_ => updatedAboutFranchisesOrLettings)
         session.saveOrUpdate(updatedData)
         Redirect(navigator.nextPage(LettingAccommodationDetailsPageId, updatedData).apply(updatedData))
       }

--- a/app/form/aboutfranchisesorlettings/AddAnotherCateringOperationOrLettingAccommodationForm.scala
+++ b/app/form/aboutfranchisesorlettings/AddAnotherCateringOperationOrLettingAccommodationForm.scala
@@ -19,7 +19,7 @@ package form.aboutfranchisesorlettings
 import form.MappingSupport.yesNoType
 import models.submissions.common.AnswersYesNo
 import play.api.data.Form
-import play.api.data.Forms.mapping
+import play.api.data.Forms.{mapping, optional}
 
 object AddAnotherCateringOperationOrLettingAccommodationForm {
 
@@ -28,7 +28,9 @@ object AddAnotherCateringOperationOrLettingAccommodationForm {
   )
 
   val baseAddAnotherCateringOperationMapping = mapping(
-    "addAnotherCateringOperationOrLettingAccommodations" -> yesNoType
+    "addAnotherCateringOperationOrLettingAccommodations" -> optional(yesNoType)
+      .verifying("error.addAnotherSeparateBusinessOrFranchise.required", _.nonEmpty)
+      .transform[AnswersYesNo](_.get, Some(_))
   )(x => x)(b => Some(b))
 
   val addAnotherCateringOperationForm = Form(baseAddAnotherCateringOperationMapping)

--- a/app/form/aboutfranchisesorlettings/AddAnotherLettingOtherPartOfPropertyForm.scala
+++ b/app/form/aboutfranchisesorlettings/AddAnotherLettingOtherPartOfPropertyForm.scala
@@ -19,7 +19,7 @@ package form.aboutfranchisesorlettings
 import form.MappingSupport.yesNoType
 import models.submissions.common.AnswersYesNo
 import play.api.data.Form
-import play.api.data.Forms.mapping
+import play.api.data.Forms.{mapping, optional}
 
 object AddAnotherLettingOtherPartOfPropertyForm {
 
@@ -28,7 +28,9 @@ object AddAnotherLettingOtherPartOfPropertyForm {
   )
 
   val baseAddAnotherLettingMapping = mapping(
-    "addAnotherLettingOtherPartOfProperty" -> yesNoType
+    "addAnotherLettingOtherPartOfProperty" -> optional(yesNoType)
+      .verifying("error.addAnotherLetting.required", _.nonEmpty)
+      .transform[AnswersYesNo](_.get, Some(_))
   )(x => x)(b => Some(b))
 
   val addAnotherLettingForm = Form(baseAddAnotherLettingMapping)

--- a/app/views/aboutfranchisesorlettings/addAnotherCateringOperationOrLettingAccommodation.scala.html
+++ b/app/views/aboutfranchisesorlettings/addAnotherCateringOperationOrLettingAccommodation.scala.html
@@ -93,7 +93,11 @@
           },
           content = Text("Change")),
          ActionItem(
-          href = "",
+          href = if (isLettingOtherPartOfProperty) {
+           controllers.aboutfranchisesorlettings.routes.AddAnotherLettingOtherPartOfPropertyController.remove(idx).url
+          } else {
+           controllers.aboutfranchisesorlettings.routes.AddAnotherCateringOperationController.remove(idx).url
+          },
           content = Text("Remove"))
         ),
         classes = "hmrc-summary-list__actions"

--- a/app/views/aboutfranchisesorlettings/addAnotherCateringOperationOrLettingAccommodation.scala.html
+++ b/app/views/aboutfranchisesorlettings/addAnotherCateringOperationOrLettingAccommodation.scala.html
@@ -14,6 +14,7 @@
  * limitations under the License.
  *@
 
+@import actions.SessionRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios
@@ -38,10 +39,36 @@
         formWithCSRF: FormWithCSRF
 )
 
-@(theForm: Form[_], index: Int, cateringOrLetting: String, backLink: String, summary: Summary)(implicit request: Request[_], messages: Messages)
+@(theForm: Form[_], index: Int, cateringOrLetting: String, backLink: String, summary: Summary)(implicit request: SessionRequest[_], messages: Messages)
+
+@session = @{ request.sessionData }
+
+@forType = @{ session.forType }
+
+@isLettingOtherPartOfProperty = @{ cateringOrLetting.equals("addAnotherLettingOtherPartOfProperty") }
+
+@formAction = @{
+ if (isLettingOtherPartOfProperty) {
+  controllers.aboutfranchisesorlettings.routes.AddAnotherLettingOtherPartOfPropertyController.submit(index)
+ } else {
+  controllers.aboutfranchisesorlettings.routes.AddAnotherCateringOperationController.submit(index)
+ }
+}
+
+@operatorNames = @{
+ session.aboutFranchisesOrLettings.fold(Seq.empty[String]){
+  fr => if (isLettingOtherPartOfProperty) {
+   fr.lettingSections.map(_.lettingOtherPartOfPropertyInformationDetails.operatorName)
+  } else {
+   fr.cateringOperationSections.map(_.cateringOperationDetails.operatorName)
+  }
+ }
+}
+
+@pluralSuffix = @{ if (operatorNames.size > 1) "s" else "" }
 
 @layout(
- pageHeading = messages(s"${cateringOrLetting}.heading", 1),
+ pageHeading = messages(s"${cateringOrLetting}.heading", operatorNames.size) + pluralSuffix,
  showSection = true,
  summary = Some(summary),
  sectionName = messages("label.section.aboutTheFranchiseLettings"),
@@ -49,36 +76,30 @@
  theForm = theForm
 ) {
 
- @formWithCSRF(action = {
-  if(cateringOrLetting.equals("addAnotherCateringOperationOrLettingAccommodations"))
-   controllers.aboutfranchisesorlettings.routes.AddAnotherCateringOperationController.submit(index)
-  else if(cateringOrLetting.equals("addAnotherLettingOtherPartOfProperty"))
-   controllers.aboutfranchisesorlettings.routes.AddAnotherLettingOtherPartOfPropertyController.submit(index)
-  else controllers.routes.TaskListController.show()},
-  args = Symbol("class") -> "myForm", Symbol("id") -> "myFormId") {
+ @formWithCSRF(action = formAction) {
 
   @govukSummaryList(
     SummaryList(
-     rows = Seq(
+     rows = operatorNames.zipWithIndex.map { case (operatorName, idx) =>
       SummaryListRow(
-       key = Key(Text("Wombles Inc"), classes = "govuk-!-font-weight-regular"),
+       key = Key(Text(operatorName), classes = "govuk-!-font-weight-regular"),
        actions = Actions(
         items = Seq(
-          ActionItem(
-            href = {if (cateringOrLetting.equals("addAnotherCateringOperationOrLettingAccommodation"))
-              controllers.aboutfranchisesorlettings.routes.CateringOperationDetailsController.show().url
-            else if (cateringOrLetting.equals("addAnotherLettingOtherPartOfProperty"))
-              controllers.aboutfranchisesorlettings.routes.LettingOtherPartOfPropertyDetailsController.show().url
-             else controllers.routes.TaskListController.show().url},
-            content = Text("Change")),
-          ActionItem(
-            href = "",
-            content = Text("Remove"))
+         ActionItem(
+          href = if (isLettingOtherPartOfProperty) {
+           controllers.aboutfranchisesorlettings.routes.LettingOtherPartOfPropertyDetailsController.show(idx).url
+          } else {
+           controllers.aboutfranchisesorlettings.routes.CateringOperationDetailsController.show(idx).url
+          },
+          content = Text("Change")),
+         ActionItem(
+          href = "",
+          content = Text("Remove"))
         ),
         classes = "hmrc-summary-list__actions"
        )
       )
-     ),
+     },
      classes = "hmrc-list-with-actions hmrc-list-with-actions--short"
     )
   )
@@ -113,5 +134,5 @@
 
   @includes.continueSaveAsDraftButtons(govukButton)
  }
-}
 
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -169,6 +169,7 @@ POST        /catering-operation-rent-includes                       controllers.
 
 GET         /add-another-catering-operation                         controllers.aboutfranchisesorlettings.AddAnotherCateringOperationController.show(idx: Int)
 POST        /add-another-catering-operation                         controllers.aboutfranchisesorlettings.AddAnotherCateringOperationController.submit(idx: Int)
+GET         /remove-catering-operation                              controllers.aboutfranchisesorlettings.AddAnotherCateringOperationController.remove(idx: Int)
 
 GET         /letting-other-part-of-property-details                 controllers.aboutfranchisesorlettings.LettingOtherPartOfPropertyDetailsController.show(idx: Option[Int] ?= None)
 POST        /letting-other-part-of-property-details                 controllers.aboutfranchisesorlettings.LettingOtherPartOfPropertyDetailsController.submit(idx: Option[Int])
@@ -181,6 +182,7 @@ POST        /letting-other-part-of-property-checkbox                controllers.
 
 GET         /add-another-letting-other-part-of-property             controllers.aboutfranchisesorlettings.AddAnotherLettingOtherPartOfPropertyController.show(idx: Int)
 POST        /add-another-letting-other-part-of-property             controllers.aboutfranchisesorlettings.AddAnotherLettingOtherPartOfPropertyController.submit(idx: Int)
+GET         /remove-letting-other-part-of-property                  controllers.aboutfranchisesorlettings.AddAnotherLettingOtherPartOfPropertyController.remove(idx: Int)
 
 # About your leace or tenure
 GET         /about-your-landlord                                    controllers.aboutYourLeaseOrTenure.AboutYourLandlordController.show()

--- a/conf/messages
+++ b/conf/messages
@@ -684,6 +684,8 @@ addAnotherCateringOperationOrLettingAccommodations.heading = You have added {0} 
 addAnotherLettingOtherPartOfProperty.heading = You have added {0} letting
 label.addAnotherCateringOperationOrLettingAccommodations = Do you need to add another separate business or franchise?
 label.addAnotherLettingOtherPartOfProperty = Do you need to add another letting?
+error.addAnotherSeparateBusinessOrFranchise.required = Select whether you need to add another separate business or franchise
+error.addAnotherLetting.required = Select whether you need to add another letting
 
 # TENANTS ADDITIONS DISREGARDED
 ###############################

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -685,6 +685,8 @@ addAnotherCateringOperationOrLettingAccommodations.heading = You have added {0} 
 addAnotherLettingOtherPartOfProperty.heading = You have added {0} letting
 label.addAnotherCateringOperationOrLettingAccommodations = Do you need to add another separate business or franchise?
 label.addAnotherLettingOtherPartOfProperty = Do you need to add another letting?
+error.addAnotherSeparateBusinessOrFranchise.required = Select whether you need to add another separate business or franchise
+error.addAnotherLetting.required = Select whether you need to add another letting
 
 # TENANTS ADDITIONS DISREGARDED
 ###############################

--- a/test/controllers/aboutfranchisesorlettings/AddAnotherCateringOperationControllerSpec.scala
+++ b/test/controllers/aboutfranchisesorlettings/AddAnotherCateringOperationControllerSpec.scala
@@ -64,7 +64,11 @@ class AddAnotherCateringOperationControllerSpec extends TestBaseSpec {
       val formData = baseFormData - errorKey.addAnotherCateringOperationOrLettingAccommodation
       val form     = addAnotherCateringOperationForm.bind(formData)
 
-      mustContainError(errorKey.addAnotherCateringOperationOrLettingAccommodation, Errors.booleanMissing, form)
+      mustContainError(
+        errorKey.addAnotherCateringOperationOrLettingAccommodation,
+        "error.addAnotherSeparateBusinessOrFranchise.required",
+        form
+      )
     }
   }
 

--- a/test/controllers/aboutfranchisesorlettings/AddAnotherLettingOtherPartOfPropertyControllerSpec.scala
+++ b/test/controllers/aboutfranchisesorlettings/AddAnotherLettingOtherPartOfPropertyControllerSpec.scala
@@ -64,7 +64,7 @@ class AddAnotherLettingOtherPartOfPropertyControllerSpec extends TestBaseSpec {
       val formData = baseFormData - errorKey.addAnotherLettingOtherPartOfProperty
       val form     = addAnotherLettingForm.bind(formData)
 
-      mustContainError(errorKey.addAnotherLettingOtherPartOfProperty, Errors.booleanMissing, form)
+      mustContainError(errorKey.addAnotherLettingOtherPartOfProperty, "error.addAnotherLetting.required", form)
     }
   }
 

--- a/test/views/aboutFranchisesOrLettings/AddAnotherCateringOperationsSpec.scala
+++ b/test/views/aboutFranchisesOrLettings/AddAnotherCateringOperationsSpec.scala
@@ -16,6 +16,7 @@
 
 package views.aboutFranchisesOrLettings
 
+import actions.SessionRequest
 import form.aboutfranchisesorlettings.AddAnotherCateringOperationOrLettingAccommodationForm
 import models.pages.Summary
 import models.submissions.common.{AnswerNo, AnswerYes, AnswersYesNo}
@@ -31,6 +32,8 @@ class AddAnotherCateringOperationsSpec extends QuestionViewBehaviours[AnswersYes
   override val form: Form[AnswersYesNo] =
     AddAnotherCateringOperationOrLettingAccommodationForm.addAnotherCateringOperationForm
 
+  val sessionRequest = SessionRequest(baseFilled6010Session, fakeRequest)
+
   def createView: () => Html = () =>
     addAnotherOperationConcessionFranchise(
       form,
@@ -38,7 +41,7 @@ class AddAnotherCateringOperationsSpec extends QuestionViewBehaviours[AnswersYes
       messageKeyPrefix,
       controllers.aboutfranchisesorlettings.routes.CateringOperationRentIncludesController.show(0).url,
       Summary("99996010001")
-    )(fakeRequest, messages)
+    )(sessionRequest, messages)
 
   def createViewUsingForm: Form[AnswersYesNo] => Html = (form: Form[AnswersYesNo]) =>
     addAnotherOperationConcessionFranchise(
@@ -47,7 +50,7 @@ class AddAnotherCateringOperationsSpec extends QuestionViewBehaviours[AnswersYes
       messageKeyPrefix,
       controllers.aboutfranchisesorlettings.routes.CateringOperationRentIncludesController.show(0).url,
       Summary("99996010001")
-    )(fakeRequest, messages)
+    )(sessionRequest, messages)
 
   "Add another catering operation view" must {
 

--- a/test/views/aboutFranchisesOrLettings/AddAnotherCateringOperationsSpec.scala
+++ b/test/views/aboutFranchisesOrLettings/AddAnotherCateringOperationsSpec.scala
@@ -54,7 +54,7 @@ class AddAnotherCateringOperationsSpec extends QuestionViewBehaviours[AnswersYes
 
   "Add another catering operation view" must {
 
-    behave like normalPageWithMessageExtra(createView, messageKeyPrefix, "1")
+    behave like normalPageWithMessageExtra(createView, messageKeyPrefix, "0")
 
     "has a link marked with back.link.label leading to the franchise or letting tied to property Page" in {
       val doc          = asDocument(createView())

--- a/test/views/aboutFranchisesOrLettings/AddAnotherLettingOtherPartOfPropertySpec.scala
+++ b/test/views/aboutFranchisesOrLettings/AddAnotherLettingOtherPartOfPropertySpec.scala
@@ -16,6 +16,7 @@
 
 package views.aboutFranchisesOrLettings
 
+import actions.SessionRequest
 import form.aboutfranchisesorlettings.AddAnotherCateringOperationOrLettingAccommodationForm
 import models.pages.Summary
 import models.submissions.common.{AnswerNo, AnswerYes, AnswersYesNo}
@@ -31,6 +32,8 @@ class AddAnotherLettingOtherPartOfPropertySpec extends QuestionViewBehaviours[An
   override val form: Form[AnswersYesNo] =
     AddAnotherCateringOperationOrLettingAccommodationForm.addAnotherCateringOperationForm
 
+  val sessionRequest = SessionRequest(baseFilled6010Session, fakeRequest)
+
   def createView: () => Html = () =>
     addAnotherOperationConcessionFranchise(
       form,
@@ -38,7 +41,7 @@ class AddAnotherLettingOtherPartOfPropertySpec extends QuestionViewBehaviours[An
       messageKeyPrefix,
       controllers.aboutfranchisesorlettings.routes.CateringOperationRentIncludesController.show(0).url,
       Summary("99996010001")
-    )(fakeRequest, messages)
+    )(sessionRequest, messages)
 
   def createViewUsingForm: Form[AnswersYesNo] => Html = (form: Form[AnswersYesNo]) =>
     addAnotherOperationConcessionFranchise(
@@ -47,7 +50,7 @@ class AddAnotherLettingOtherPartOfPropertySpec extends QuestionViewBehaviours[An
       messageKeyPrefix,
       controllers.aboutfranchisesorlettings.routes.CateringOperationRentIncludesController.show(0).url,
       Summary("99996010001")
-    )(fakeRequest, messages)
+    )(sessionRequest, messages)
 
   "Add another letting part of property view" must {
 

--- a/test/views/aboutFranchisesOrLettings/AddAnotherLettingOtherPartOfPropertySpec.scala
+++ b/test/views/aboutFranchisesOrLettings/AddAnotherLettingOtherPartOfPropertySpec.scala
@@ -54,7 +54,7 @@ class AddAnotherLettingOtherPartOfPropertySpec extends QuestionViewBehaviours[An
 
   "Add another letting part of property view" must {
 
-    behave like normalPageWithMessageExtra(createView, messageKeyPrefix, "1")
+    behave like normalPageWithMessageExtra(createView, messageKeyPrefix, "0")
 
     "has a link marked with back.link.label leading to the franchise or letting tied to property Page" in {
       val doc          = asDocument(createView())


### PR DESCRIPTION
- Refactoring template. Showing operator names in table. Implemented `"Change"` link
- Fixed saving in session and passing between pages current idx for Add / Change operations in both catering/franchises and lettings journeys
- Implemented `"Remove"` buttons and endpoints. Handling `edge case` when sections list become `empty`.
- Form validation "Select whether you need to add another separate business or franchise"
- Updated according to latest changes unit tests `AddAnotherCateringOperationsSpec`, `AddAnotherLettingOtherPartOfPropertySpec`