### PR TITLE
BST-64638 Remove auto-population of zeroes on Trading History pages

### DIFF
--- a/app/controllers/aboutthetradinghistory/AboutYourTradingHistoryController.scala
+++ b/app/controllers/aboutthetradinghistory/AboutYourTradingHistoryController.scala
@@ -80,7 +80,7 @@ class AboutYourTradingHistoryController @Inject() (
                   averageOccupancyRate = None
                 )
               },
-              costOfSales = financialYearsList.map(CostOfSales(_, 0, 0, 0, 0))
+              costOfSales = financialYearsList.map(CostOfSales(_, None, None, None, None))
             )
           )
           session

--- a/app/controllers/aboutthetradinghistory/AboutYourTradingHistoryController.scala
+++ b/app/controllers/aboutthetradinghistory/AboutYourTradingHistoryController.scala
@@ -73,11 +73,11 @@ class AboutYourTradingHistoryController @Inject() (
                 TurnoverSection(
                   financialYearEnd = finYearEnd,
                   tradingPeriod = 52,
-                  alcoholicDrinks = 0,
-                  food = 0,
-                  otherReceipts = 0,
-                  accommodation = 0,
-                  averageOccupancyRate = 0
+                  alcoholicDrinks = None,
+                  food = None,
+                  otherReceipts = None,
+                  accommodation = None,
+                  averageOccupancyRate = None
                 )
               },
               costOfSales = financialYearsList.map(CostOfSales(_, 0, 0, 0, 0))

--- a/app/controllers/aboutthetradinghistory/CheckYourAnswersAboutTheTradingHistoryController.scala
+++ b/app/controllers/aboutthetradinghistory/CheckYourAnswersAboutTheTradingHistoryController.scala
@@ -40,7 +40,8 @@ class CheckYourAnswersAboutTheTradingHistoryController @Inject() (
   checkYourAnswersAboutTheTradingHistoryView: checkYourAnswersAboutTheTradingHistory,
   withSessionRefiner: WithSessionRefiner,
   @Named("session") val session: SessionRepo
-)(implicit ec: ExecutionContext) extends FORDataCaptureController(mcc)
+)(implicit ec: ExecutionContext)
+    extends FORDataCaptureController(mcc)
     with I18nSupport
     with Logging {
 
@@ -76,8 +77,9 @@ class CheckYourAnswersAboutTheTradingHistoryController @Inject() (
           .copy(lastCYAPageUrl =
             Some(controllers.aboutthetradinghistory.routes.CheckYourAnswersAboutTheTradingHistoryController.show().url)
           )
-        session.saveOrUpdate(updatedData).flatMap( _ =>
-        Future.successful(Redirect(navigator.nextPage(CheckYourAnswersAboutTheTradingHistoryId, updatedData).apply(updatedData))))
+        session.saveOrUpdate(updatedData).map { _ =>
+          Redirect(navigator.nextPage(CheckYourAnswersAboutTheTradingHistoryId, updatedData).apply(updatedData))
+        }
       }
     )
   }

--- a/app/controllers/aboutthetradinghistory/CostOfSalesController.scala
+++ b/app/controllers/aboutthetradinghistory/CostOfSalesController.scala
@@ -52,7 +52,7 @@ class CostOfSalesController @Inject() (
             val financialYearsList = AccountingInformationUtil.financialYearsRequired(
               aboutTheTradingHistory.occupationAndAccountingInformation.get
             )
-            val initialCostOfSales = financialYearsList.map(CostOfSales(_, 0, 0, 0, 0))
+            val initialCostOfSales = financialYearsList.map(CostOfSales(_, None, None, None, None))
             val updatedData        = updateAboutTheTradingHistory(_.copy(costOfSales = initialCostOfSales))
             session.saveOrUpdate(updatedData)
             initialCostOfSales

--- a/app/form/aboutthetradinghistory/CostOfSalesForm.scala
+++ b/app/form/aboutthetradinghistory/CostOfSalesForm.scala
@@ -25,10 +25,10 @@ object CostOfSalesForm {
 
   val columnMapping: Mapping[CostOfSales] = mapping(
     "financial-year-end" -> localDate("dd/MM/yyyy").verifying(dateTooEarlyConstraint),
-    "accommodation"      -> bigDecimal,
-    "food"               -> bigDecimal,
-    "drinks"             -> bigDecimal,
-    "other"              -> bigDecimal
+    "accommodation"      -> optional(bigDecimal),
+    "food"               -> optional(bigDecimal),
+    "drinks"             -> optional(bigDecimal),
+    "other"              -> optional(bigDecimal)
   )(CostOfSales.apply)(CostOfSales.unapply)
 
   val costOfSalesForm: Form[Seq[CostOfSales]] = Form(

--- a/app/form/aboutthetradinghistory/TurnoverForm.scala
+++ b/app/form/aboutthetradinghistory/TurnoverForm.scala
@@ -19,7 +19,7 @@ package form.aboutthetradinghistory
 import form.DateMappings.dateTooEarlyConstraint
 import models.submissions.aboutthetradinghistory.TurnoverSection
 import play.api.data.{Form, Mapping}
-import play.api.data.Forms.{bigDecimal, localDate, mapping, number}
+import play.api.data.Forms.{bigDecimal, localDate, mapping, number, optional}
 import play.api.data.validation.{Constraint, Invalid, Valid}
 
 object TurnoverForm {
@@ -33,11 +33,11 @@ object TurnoverForm {
     val columnMapping: Mapping[TurnoverSection]            = mapping(
       "financial-year-end"     -> ukDateMappings.verifying(dateTooEarlyConstraint),
       "weeks"                  -> number(min = 0, max = 52),
-      "alcoholic-drinks"       -> bigDecimal,
-      "food"                   -> bigDecimal,
-      "other-receipts"         -> bigDecimal,
-      "accommodation"          -> bigDecimal,
-      "average-occupancy-rate" -> bigDecimal.verifying(averageOccupancyConstraint)
+      "alcoholic-drinks"       -> optional(bigDecimal),
+      "food"                   -> optional(bigDecimal),
+      "other-receipts"         -> optional(bigDecimal),
+      "accommodation"          -> optional(bigDecimal),
+      "average-occupancy-rate" -> optional(bigDecimal.verifying(averageOccupancyConstraint))
     )(TurnoverSection.apply)(TurnoverSection.unapply)
 
     Form {

--- a/app/models/submissions/aboutthetradinghistory/CostOfSales.scala
+++ b/app/models/submissions/aboutthetradinghistory/CostOfSales.scala
@@ -17,17 +17,20 @@
 package models.submissions.aboutthetradinghistory
 
 import play.api.libs.json.Json
+import util.NumberUtil.zeroBigDecimal
 
 import java.time.LocalDate
 
 case class CostOfSales(
   financialYearEnd: LocalDate,
-  accommodation: BigDecimal,
-  food: BigDecimal,
-  drinks: BigDecimal,
-  other: BigDecimal
+  accommodation: Option[BigDecimal],
+  food: Option[BigDecimal],
+  drinks: Option[BigDecimal],
+  other: Option[BigDecimal]
 ) {
-  def total: BigDecimal = accommodation + food + drinks + other
+  def total: BigDecimal =
+    accommodation.getOrElse(zeroBigDecimal) + food.getOrElse(zeroBigDecimal) +
+      drinks.getOrElse(zeroBigDecimal) + other.getOrElse(zeroBigDecimal)
 }
 
 object CostOfSales {

--- a/app/models/submissions/aboutthetradinghistory/TurnoverSection.scala
+++ b/app/models/submissions/aboutthetradinghistory/TurnoverSection.scala
@@ -23,12 +23,13 @@ import java.time.LocalDate
 case class TurnoverSection(
   financialYearEnd: LocalDate,
   tradingPeriod: Int,
-  alcoholicDrinks: BigDecimal,
-  food: BigDecimal,
-  otherReceipts: BigDecimal,
-  accommodation: BigDecimal,
-  averageOccupancyRate: BigDecimal
+  alcoholicDrinks: Option[BigDecimal],
+  food: Option[BigDecimal],
+  otherReceipts: Option[BigDecimal],
+  accommodation: Option[BigDecimal],
+  averageOccupancyRate: Option[BigDecimal]
 )
+
 object TurnoverSection {
   implicit val format = Json.format[TurnoverSection]
 }

--- a/app/util/NumberUtil.scala
+++ b/app/util/NumberUtil.scala
@@ -25,6 +25,8 @@ import scala.math.BigDecimal.RoundingMode.HALF_UP
   */
 object NumberUtil {
 
+  val zeroBigDecimal: BigDecimal = BigDecimal(0)
+
   implicit class stringHelpers(str: String) {
     def removeTrailingZeros: String =
       str.replace(".00", "")

--- a/app/views/aboutthetradinghistory/costOfSales.scala.html
+++ b/app/views/aboutthetradinghistory/costOfSales.scala.html
@@ -103,9 +103,6 @@
         <li>@messages("costOfSales.excluding.item4")</li>
     </ul>
 
-    @govukInsetText(InsetText(
-        content = Text(messages("costOfSales.note"))
-    ))
     @govukDetails(Details(
         summary = Text(messages("costOfSales.details.link")),
         content = HtmlContent(detailsContent)

--- a/app/views/aboutthetradinghistory/turnover.scala.html
+++ b/app/views/aboutthetradinghistory/turnover.scala.html
@@ -86,9 +86,6 @@
       @* TODO - Reinstate paragraph when cut and paste functionality developed *@
       @*<p class="govuk-body">@messages("turnover.p2")</p>*@
 
-      @govukInsetText(InsetText(
-          content = Text(messages("turnover.inset"))
-      ))
       @govukDetails(Details(
           summary = Text(messages("turnover.details")),
           content = HtmlContent(detailsContent)

--- a/app/views/aboutthetradinghistory/turnover1516.scala.html
+++ b/app/views/aboutthetradinghistory/turnover1516.scala.html
@@ -86,9 +86,6 @@
     @formWithCSRF(action = controllers.aboutthetradinghistory.routes.TurnoverController.submit, args = 'class -> "myForm", 'id -> "myFormId") {
 
         <p class="govuk-body">@messages("turnover.p1")</p>
-        @govukInsetText(InsetText(
-            content = Text(messages("turnover.inset"))
-        ))
         @govukDetails(Details(
             summary = Text(messages("turnover.details.6016")),
             content = HtmlContent(detailsContent)

--- a/app/views/answers/answersAboutYourTradingHistory.scala.html
+++ b/app/views/answers/answersAboutYourTradingHistory.scala.html
@@ -48,11 +48,11 @@
         turnoverSections.map(t => Seq(
             dateUtil.formatDayMonthAbbrYear(t.financialYearEnd),
             s"${t.tradingPeriod} ${messages("turnover.weeks")}",
-            t.alcoholicDrinks.asMoney,
-            t.food.asMoney,
-            t.otherReceipts.asMoney,
-            t.accommodation.asMoney,
-            t.averageOccupancyRate.withScale(2) + "%"
+            t.alcoholicDrinks.getOrElse(zeroBigDecimal).asMoney,
+            t.food.getOrElse(zeroBigDecimal).asMoney,
+            t.otherReceipts.getOrElse(zeroBigDecimal).asMoney,
+            t.accommodation.getOrElse(zeroBigDecimal).asMoney,
+            t.averageOccupancyRate.getOrElse(zeroBigDecimal).withScale(2) + "%"
         ))
     ).body
 }

--- a/conf/messages
+++ b/conf/messages
@@ -1088,7 +1088,6 @@ costOfSales.excluding.item1 = payroll costs
 costOfSales.excluding.item2 = variable operating expenses
 costOfSales.excluding.item3 = fixed operating expenses
 costOfSales.excluding.item4 = other costs
-costOfSales.note = All fields on this page are mandatory. If none of the categories are applicable, enter the number 0.
 costOfSales.details.link = Help with completing this page
 costOfSales.details.h1 = General guidance
 costOfSales.details.p1 = Do not include VAT in any of the figures you declare on this page.

--- a/conf/messages
+++ b/conf/messages
@@ -1042,7 +1042,6 @@ error.costOfSales.maxColumns = Number of columns must be between 1 and 3
 turnover.heading = Turnover
 turnover.p1 = Provide us with details of your turnover. If the accounts do not relate to a whole year, or if you are not trading continuously, state the relevant number of weeks.
 turnover.p2 = If your accounts are held in a spreadsheet that mirrors this form, you can copy and paste them into this form. Copy the relevant figures in your spreadsheet and paste them into the first corresponding field on this page.
-turnover.inset = All fields on this page are mandatory. If none of the categories are applicable, enter the number 0.
 turnover.financialYearEnd = Financial year end
 turnover.tradingPeriod = Trading period
 turnover.alcoholicDrinks = Alcoholic drinks (excluding VAT)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1026,7 +1026,6 @@ error.costOfSales.maxColumns = Number of columns must be between 1 and 3
 turnover.heading = Turnover
 turnover.p1 = Provide us with details of your turnover. If the accounts do not relate to a whole year, or if you are not trading continuously, state the relevant number of weeks.
 turnover.p2 = If your accounts are held in a spreadsheet that mirrors this form, you can copy and paste them into this form. Copy the relevant figures in your spreadsheet and paste them into the first corresponding field on this page.
-turnover.inset = All fields on this page are mandatory. If none of the categories are applicable, enter the number 0.
 turnover.financialYearEnd = Financial year end
 turnover.tradingPeriod = Trading period
 turnover.alcoholicDrinks = Alcoholic drinks (excluding VAT)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1072,7 +1072,6 @@ costOfSales.excluding.item1 = payroll costs
 costOfSales.excluding.item2 = variable operating expenses
 costOfSales.excluding.item3 = fixed operating expenses
 costOfSales.excluding.item4 = other costs
-costOfSales.note = All fields on this page are mandatory. If none of the categories are applicable, enter the number 0.
 costOfSales.details.link = Help with completing this page
 costOfSales.details.h1 = General guidance
 costOfSales.details.p1 = Do not include VAT in any of the figures you declare on this page.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object AppDependencies {
 
   val bootstrapVersion = "7.22.0"
-  val playFrontendVersion = "7.20.0-play-28"
+  val playFrontendVersion = "7.23.0-play-28"
   val mongoVersion = "1.3.0"
   val cryptoJsonVersion = "7.3.0"
   val jodaVersion = "2.9.4"

--- a/test/utils/FakeObjects.scala
+++ b/test/utils/FakeObjects.scala
@@ -253,11 +253,11 @@ trait FakeObjects {
       TurnoverSection(
         LocalDate.now(),
         123,
-        BigDecimal(234),
-        BigDecimal(345),
-        BigDecimal(456),
-        BigDecimal(567),
-        BigDecimal(678)
+        Some(BigDecimal(234)),
+        Some(BigDecimal(345)),
+        Some(BigDecimal(456)),
+        Some(BigDecimal(567)),
+        Some(BigDecimal(678))
       )
     )
   )

--- a/test/views/aboutthetradinghistory/TurnoverViewSpec.scala
+++ b/test/views/aboutthetradinghistory/TurnoverViewSpec.scala
@@ -57,7 +57,6 @@ class TurnoverViewSpec extends QuestionViewBehaviours[Seq[TurnoverSection]] {
       assert(doc.toString.contains(messages("turnover.p1")))
       // TODO - Reinstate paragraph when cut and paste functionality developed
 //      assert(doc.toString.contains(messages("turnover.p2")))
-      assert(doc.toString.contains(messages("turnover.inset")))
     }
 
     "contain get help section" in {


### PR DESCRIPTION
- Refactored `TurnoverForm` values type from `BigDecimal` to `Option[BigDecimal]` - for page [/turnover](https://www.qa.tax.service.gov.uk/send-trade-and-cost-information/turnover)
- Refactored `CostOfSalesForm` values type from `BigDecimal` to `Option[BigDecimal]` - for page [/cost-of-sales](https://www.qa.tax.service.gov.uk/send-trade-and-cost-information/cost-of-sales)
