### PR TITLE
BST-73241 Fixed a few a11y issues

### DIFF
--- a/app/views/aboutthetradinghistory/turnover.scala.html
+++ b/app/views/aboutthetradinghistory/turnover.scala.html
@@ -121,7 +121,10 @@
                                       name = s"$idx.weeks",
                                       value = form(s"$idx.weeks").value,
                                       classes = "govuk-input--width-2",
-                                      attributes = Map("maxlength" -> "2"),
+                                      attributes = Map(
+                                          "maxlength" -> "2",
+                                          "aria-label" -> messages("turnover.tradingPeriod")
+                                      ),
                                       suffix = Some(PrefixOrSuffix(
                                           content = Text(messages("turnover.weeks"))
                                       ))
@@ -138,6 +141,10 @@
                                   id = s"$idx.alcoholic-drinks",
                                   name = s"$idx.alcoholic-drinks",
                                   value = form(s"$idx.alcoholic-drinks").value,
+                                  attributes = Map(
+                                      "maxlength" -> "13",
+                                      "aria-label" -> messages("turnover.alcoholicDrinks")
+                                  ),
                                   prefix = Some(PrefixOrSuffix(
                                       content = Text("£")
                                   ))
@@ -154,6 +161,10 @@
                                       id = s"$idx.food",
                                       name = s"$idx.food",
                                       value = form(s"$idx.food").value,
+                                      attributes = Map(
+                                          "maxlength" -> "13",
+                                          "aria-label" -> messages("turnover.food")
+                                      ),
                                       prefix = Some(PrefixOrSuffix(
                                           content = Text("£")
                                       ))
@@ -170,6 +181,10 @@
                                       id = s"$idx.other-receipts",
                                       name = s"$idx.other-receipts",
                                       value = form(s"$idx.other-receipts").value,
+                                      attributes = Map(
+                                          "maxlength" -> "13",
+                                          "aria-label" -> messages("turnover.otherReceipts")
+                                      ),
                                       prefix = Some(PrefixOrSuffix(
                                           content = Text("£")
                                       ))
@@ -186,6 +201,10 @@
                                       id = s"$idx.accommodation",
                                       name = s"$idx.accommodation",
                                       value = form(s"$idx.accommodation").value,
+                                      attributes = Map(
+                                          "maxlength" -> "13",
+                                          "aria-label" -> messages("turnover.accommodation")
+                                      ),
                                       prefix = Some(PrefixOrSuffix(
                                           content = Text("£")
                                       ))
@@ -203,7 +222,10 @@
                                       name = s"$idx.average-occupancy-rate",
                                       value = form(s"$idx.average-occupancy-rate").value,
                                       classes = "govuk-input--width-3",
-                                      attributes = Map("maxlength" -> "5"),
+                                      attributes = Map(
+                                          "maxlength" -> "5",
+                                          "aria-label" -> messages("turnover.averageOccupancyRate")
+                                      ),
                                       suffix = Some(PrefixOrSuffix(
                                           content = Text("%")
                                       ))

--- a/app/views/answers/answersAboutYourTradingHistory.scala.html
+++ b/app/views/answers/answersAboutYourTradingHistory.scala.html
@@ -35,11 +35,11 @@
 
 @table(valuesGrid: Seq[Seq[String]]) = {
 @valuesGrid.map { values =>
-    <span class="hmrc-turnover-table-column">
+    <div class="hmrc-turnover-table-column">
         @values.map { value =>
             <p class="govuk-body">@value</p>
         }
-    </span>
+    </div>
 }
 }
 

--- a/app/views/includes/javascripts.scala.html
+++ b/app/views/includes/javascripts.scala.html
@@ -21,17 +21,17 @@
 
 @()
 <!-- Javascript -->
-<script type="text/javascript">
+<script>
         document.documentElement.className = document.documentElement.className.replace("no-js","js");
 </script>
 
-<script src="@routes.Assets.versioned("lib/jquery/jquery.min.js")" type="text/javascript"></script>
+<script src="@routes.Assets.versioned("lib/jquery/jquery.min.js")"></script>
 @if(environment.mode == Dev){
-    <script src="@routes.Assets.versioned(s"javascripts/app.js")" type="text/javascript"></script>
+    <script src="@routes.Assets.versioned(s"javascripts/app.js")"></script>
 }else{
-    <script src="@routes.Assets.versioned("javascripts/app.min.js")" type="text/javascript"></script>
+    <script src="@routes.Assets.versioned("javascripts/app.min.js")"></script>
 }
-<script src="@routes.Assets.versioned("javascripts/vendor/typeahead.bundle.min.js")" type="text/javascript"></script>
-<script src="@routes.Assets.versioned("javascripts/vendor/jsconf.min.js")" type="text/javascript"></script>
-<script src="@routes.Assets.versioned("javascripts/polyfills/details.polyfill.min.js")" type="text/javascript"></script>
-<script src="@routes.Assets.versioned("javascripts/polyfills/toISOString.polyfill.min.js")" type="text/javascript"></script>
+<script src="@routes.Assets.versioned("javascripts/vendor/typeahead.bundle.min.js")"></script>
+<script src="@routes.Assets.versioned("javascripts/vendor/jsconf.min.js")"></script>
+<script src="@routes.Assets.versioned("javascripts/polyfills/details.polyfill.min.js")"></script>
+<script src="@routes.Assets.versioned("javascripts/polyfills/toISOString.polyfill.min.js")"></script>


### PR DESCRIPTION
- Fixed issue - *The “type” attribute is unnecessary for JavaScript resources.* on all affected pages
- Fixed issue - *Element “p” not allowed as child of element “span” in this context.* on all affected pages
- Fixed issue on turnover form - *Form element does not have an implicit (wrapped) <label> Form element does not have an explicit <label> aria-label attribute does not exist or is empty aria-labelledby attribute*