### PR TITLE
BST-73222 `Trading history` as per latest Mural

### DIFF
--- a/app/controllers/aboutthetradinghistory/CostOfSalesController.scala
+++ b/app/controllers/aboutthetradinghistory/CostOfSalesController.scala
@@ -73,7 +73,12 @@ class CostOfSalesController @Inject() (
           val updatedData = updateAboutTheTradingHistory(_.copy(costOfSales = costOfSales))
           session
             .saveOrUpdate(updatedData)
-            .map(_ => Redirect(navigator.nextPage(CostOfSalesId, updatedData).apply(updatedData)))
+            .map(_ =>
+              navigator.cyaPage
+                .filter(_ => navigator.from == "CYA" && aboutTheTradingHistory.totalPayrollCostSections.nonEmpty)
+                .getOrElse(navigator.nextPage(CostOfSalesId, updatedData).apply(updatedData))
+            )
+            .map(Redirect)
         }
       )
     }

--- a/app/controllers/aboutthetradinghistory/CostOfSalesController.scala
+++ b/app/controllers/aboutthetradinghistory/CostOfSalesController.scala
@@ -16,15 +16,15 @@
 
 package controllers.aboutthetradinghistory
 
-import actions.WithSessionRefiner
+import actions.{SessionRequest, WithSessionRefiner}
 import controllers.FORDataCaptureController
 import form.aboutthetradinghistory.CostOfSalesForm.costOfSalesForm
 import models.submissions.aboutthetradinghistory.AboutTheTradingHistory.updateAboutTheTradingHistory
-import models.submissions.aboutthetradinghistory.CostOfSales
+import models.submissions.aboutthetradinghistory.{AboutTheTradingHistory, CostOfSales}
 import navigation.AboutTheTradingHistoryNavigator
 import navigation.identifiers.CostOfSalesId
 import play.api.i18n.I18nSupport
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import repositories.SessionRepo
 import views.html.aboutthetradinghistory.costOfSales
 
@@ -42,35 +42,52 @@ class CostOfSalesController @Inject() (
     extends FORDataCaptureController(mcc)
     with I18nSupport {
 
-  def show: Action[AnyContent] = (Action andThen withSessionRefiner) { implicit request =>
-    request.sessionData.aboutTheTradingHistory
-      .filter(_.occupationAndAccountingInformation.isDefined)
-      .filter(_.costOfSales.nonEmpty)
-      .fold(Redirect(routes.AboutYourTradingHistoryController.show())) { aboutTheTradingHistory =>
-        Ok(
-          costOfSalesView(costOfSalesForm.fillAndValidate(aboutTheTradingHistory.costOfSales))
-        )
+  def show: Action[AnyContent] = (Action andThen withSessionRefiner).async { implicit request =>
+    runWithSessionCheck { aboutTheTradingHistory =>
+      val costOfSales = if (aboutTheTradingHistory.costOfSales.size == aboutTheTradingHistory.turnoverSections.size) {
+        (aboutTheTradingHistory.costOfSales zip financialYearEndDates(aboutTheTradingHistory)).map {
+          case (costOfSales, finYearEnd) => costOfSales.copy(financialYearEnd = finYearEnd)
+        }
+      } else {
+        financialYearEndDates(aboutTheTradingHistory).map(CostOfSales(_, None, None, None, None))
       }
+
+      val updatedData = updateAboutTheTradingHistory(_.copy(costOfSales = costOfSales))
+      session
+        .saveOrUpdate(updatedData)
+        .map(_ => Ok(costOfSalesView(costOfSalesForm.fillAndValidate(costOfSales))))
+    }
   }
 
   def submit: Action[AnyContent] = (Action andThen withSessionRefiner).async { implicit request =>
+    runWithSessionCheck { aboutTheTradingHistory =>
+      continueOrSaveAsDraft[Seq[CostOfSales]](
+        costOfSalesForm,
+        formWithErrors => BadRequest(costOfSalesView(formWithErrors)),
+        data => {
+          val costOfSales =
+            (data zip financialYearEndDates(aboutTheTradingHistory)).map { case (costOfSales, finYearEnd) =>
+              costOfSales.copy(financialYearEnd = finYearEnd)
+            }
+
+          val updatedData = updateAboutTheTradingHistory(_.copy(costOfSales = costOfSales))
+          session
+            .saveOrUpdate(updatedData)
+            .map(_ => Redirect(navigator.nextPage(CostOfSalesId, updatedData).apply(updatedData)))
+        }
+      )
+    }
+  }
+
+  private def runWithSessionCheck(
+    action: AboutTheTradingHistory => Future[Result]
+  )(implicit request: SessionRequest[AnyContent]) =
     request.sessionData.aboutTheTradingHistory
       .filter(_.occupationAndAccountingInformation.isDefined)
-      .fold(Future.successful(Redirect(routes.AboutYourTradingHistoryController.show()))) { aboutTheTradingHistory =>
-        continueOrSaveAsDraft[Seq[CostOfSales]](
-          costOfSalesForm,
-          formWithErrors =>
-            BadRequest(
-              costOfSalesView(formWithErrors)
-            ),
-          data => {
-            val updatedData = updateAboutTheTradingHistory(_.copy(costOfSales = data))
-            session
-              .saveOrUpdate(updatedData)
-              .map(_ => Redirect(navigator.nextPage(CostOfSalesId, updatedData).apply(updatedData)))
-          }
-        )
-      }
-  }
+      .filter(_.turnoverSections.nonEmpty)
+      .fold(Future.successful(Redirect(routes.AboutYourTradingHistoryController.show())))(action)
+
+  private def financialYearEndDates(aboutTheTradingHistory: AboutTheTradingHistory) =
+    aboutTheTradingHistory.turnoverSections.map(_.financialYearEnd)
 
 }

--- a/app/controllers/aboutthetradinghistory/FinancialYearEndController.scala
+++ b/app/controllers/aboutthetradinghistory/FinancialYearEndController.scala
@@ -21,7 +21,7 @@ import controllers.FORDataCaptureController
 import form.aboutthetradinghistory.AccountingInformationForm.accountingInformationForm
 import models.submissions.Form6010.DayMonthsDuration
 import models.submissions.aboutthetradinghistory.AboutTheTradingHistory.updateAboutTheTradingHistory
-import models.submissions.aboutthetradinghistory.{OccupationalAndAccountingInformation, TurnoverSection}
+import models.submissions.aboutthetradinghistory.{CostOfSales, OccupationalAndAccountingInformation, TurnoverSection}
 import navigation.AboutTheTradingHistoryNavigator
 import navigation.identifiers.FinancialYearEndPageId
 import play.api.Logging
@@ -100,6 +100,14 @@ class FinancialYearEndController @Inject() (
               }
             }
 
+            val costOfSales = if (aboutTheTradingHistory.costOfSales.size == turnoverSections.size) {
+              (aboutTheTradingHistory.costOfSales zip turnoverSections.map(_.financialYearEnd)).map {
+                case (costOfSales, finYearEnd) => costOfSales.copy(financialYearEnd = finYearEnd)
+              }
+            } else {
+              turnoverSections.map(_.financialYearEnd).map(CostOfSales(_, None, None, None, None))
+            }
+
             val sectionCompleted = if (isFinancialYearsListUnchanged) {
               aboutTheTradingHistory.checkYourAnswersAboutTheTradingHistory
             } else {
@@ -110,6 +118,7 @@ class FinancialYearEndController @Inject() (
               _.copy(
                 occupationAndAccountingInformation = Some(newOccupationAndAccounting),
                 turnoverSections = turnoverSections,
+                costOfSales = costOfSales,
                 checkYourAnswersAboutTheTradingHistory = sectionCompleted
               )
             )

--- a/app/controllers/aboutthetradinghistory/FinancialYearEndDatesController.scala
+++ b/app/controllers/aboutthetradinghistory/FinancialYearEndDatesController.scala
@@ -20,6 +20,7 @@ import actions.WithSessionRefiner
 import controllers.FORDataCaptureController
 import form.aboutthetradinghistory.FinancialYearEndDatesForm.financialYearEndDatesForm
 import models.submissions.aboutthetradinghistory.AboutTheTradingHistory.updateAboutTheTradingHistory
+import models.submissions.aboutthetradinghistory.CostOfSales
 import navigation.AboutTheTradingHistoryNavigator
 import navigation.identifiers.FinancialYearEndDatesPageId
 import play.api.i18n.I18nSupport
@@ -89,10 +90,19 @@ class FinancialYearEndDatesController @Inject() (
                 turnoverSection.copy(financialYearEnd = finYearEnd)
               }
 
+            val costOfSales = if (aboutTheTradingHistory.costOfSales.size == turnoverSections.size) {
+              (aboutTheTradingHistory.costOfSales zip turnoverSections.map(_.financialYearEnd)).map {
+                case (costOfSales, finYearEnd) => costOfSales.copy(financialYearEnd = finYearEnd)
+              }
+            } else {
+              turnoverSections.map(_.financialYearEnd).map(CostOfSales(_, None, None, None, None))
+            }
+
             val updatedData = updateAboutTheTradingHistory(
               _.copy(
                 occupationAndAccountingInformation = Some(newOccupationAndAccounting),
-                turnoverSections = turnoverSections
+                turnoverSections = turnoverSections,
+                costOfSales = costOfSales
               )
             )
 

--- a/app/controllers/aboutthetradinghistory/FixedOperatingExpensesController.scala
+++ b/app/controllers/aboutthetradinghistory/FixedOperatingExpensesController.scala
@@ -54,7 +54,7 @@ class FixedOperatingExpensesController @Inject() (
         Ok(
           fixedOperatingExpensesView(
             fixedOperatingExpensesForm(numberOfColumns)
-              .fillAndValidate(aboutTheTradingHistory.fixedOperatingExpensesSections),
+              .fill(aboutTheTradingHistory.fixedOperatingExpensesSections),
             numberOfColumns,
             financialYears,
             request.sessionData.toSummary

--- a/app/controllers/aboutthetradinghistory/TotalPayrollCostsController.scala
+++ b/app/controllers/aboutthetradinghistory/TotalPayrollCostsController.scala
@@ -53,7 +53,7 @@ class TotalPayrollCostsController @Inject() (
         )
         Ok(
           totalPayrollCostsView(
-            totalPayrollCostForm(numberOfColumns).fillAndValidate(aboutTheTradingHistory.totalPayrollCostSections),
+            totalPayrollCostForm(numberOfColumns).fill(aboutTheTradingHistory.totalPayrollCostSections),
             numberOfColumns,
             financialYears,
             request.sessionData.toSummary

--- a/app/controllers/aboutthetradinghistory/TurnoverController.scala
+++ b/app/controllers/aboutthetradinghistory/TurnoverController.scala
@@ -76,7 +76,12 @@ class TurnoverController @Inject() (
             )
             session
               .saveOrUpdate(updatedData)
-              .map(_ => Redirect(navigator.nextPage(TurnoverPageId, updatedData).apply(updatedData)))
+              .map(_ =>
+                navigator.cyaPage
+                  .filter(_ => navigator.from == "CYA" && aboutTheTradingHistory.costOfSales.head.drinks.isDefined)
+                  .getOrElse(navigator.nextPage(TurnoverPageId, updatedData).apply(updatedData))
+              )
+              .map(Redirect)
           }
         )
       }

--- a/app/controllers/aboutthetradinghistory/TurnoverController.scala
+++ b/app/controllers/aboutthetradinghistory/TurnoverController.scala
@@ -20,7 +20,7 @@ import actions.WithSessionRefiner
 import controllers.FORDataCaptureController
 import form.aboutthetradinghistory.TurnoverForm.turnoverForm
 import models.submissions.aboutthetradinghistory.AboutTheTradingHistory.updateAboutTheTradingHistory
-import models.submissions.aboutthetradinghistory.{CostOfSales, TurnoverSection}
+import models.submissions.aboutthetradinghistory.{AboutTheTradingHistory, TurnoverSection}
 import navigation.AboutTheTradingHistoryNavigator
 import navigation.identifiers.TurnoverPageId
 import play.api.i18n.I18nSupport
@@ -64,10 +64,14 @@ class TurnoverController @Inject() (
           turnoverForm(numberOfColumns),
           formWithErrors => BadRequest(turnoverView(formWithErrors)),
           success => {
+            val turnoverSections =
+              (success zip financialYearEndDates(aboutTheTradingHistory)).map { case (turnoverSection, finYearEnd) =>
+                turnoverSection.copy(financialYearEnd = finYearEnd)
+              }
+
             val updatedData = updateAboutTheTradingHistory(
               _.copy(
-                turnoverSections = success,
-                costOfSales = success.map(_.financialYearEnd).map(CostOfSales(_, None, None, None, None))
+                turnoverSections = turnoverSections
               )
             )
             session
@@ -77,5 +81,8 @@ class TurnoverController @Inject() (
         )
       }
   }
+
+  private def financialYearEndDates(aboutTheTradingHistory: AboutTheTradingHistory) =
+    aboutTheTradingHistory.turnoverSections.map(_.financialYearEnd)
 
 }

--- a/app/controllers/aboutthetradinghistory/VariableOperatingExpensesController.scala
+++ b/app/controllers/aboutthetradinghistory/VariableOperatingExpensesController.scala
@@ -53,7 +53,7 @@ class VariableOperatingExpensesController @Inject() (
         Ok(
           variableOperativeExpensesView(
             variableOperatingExpensesForm(numberOfColumns)
-              .fillAndValidate(aboutTheTradingHistory.variableOperatingExpensesSections),
+              .fill(aboutTheTradingHistory.variableOperatingExpensesSections),
             numberOfColumns,
             financialYears,
             request.sessionData.toSummary

--- a/app/form/aboutthetradinghistory/CostOfSalesForm.scala
+++ b/app/form/aboutthetradinghistory/CostOfSalesForm.scala
@@ -16,15 +16,16 @@
 
 package form.aboutthetradinghistory
 
-import form.DateMappings.dateTooEarlyConstraint
 import models.submissions.aboutthetradinghistory.CostOfSales
 import play.api.data.Forms._
 import play.api.data.{Form, Mapping}
 
+import java.time.LocalDate
+
 object CostOfSalesForm {
 
   val columnMapping: Mapping[CostOfSales] = mapping(
-    "financial-year-end" -> localDate("dd/MM/yyyy").verifying(dateTooEarlyConstraint),
+    "financial-year-end" -> optional(text).transform[LocalDate](_ => LocalDate.EPOCH, _ => Some("")),
     "accommodation"      -> optional(bigDecimal),
     "food"               -> optional(bigDecimal),
     "drinks"             -> optional(bigDecimal),

--- a/app/form/aboutthetradinghistory/TurnoverForm.scala
+++ b/app/form/aboutthetradinghistory/TurnoverForm.scala
@@ -16,12 +16,13 @@
 
 package form.aboutthetradinghistory
 
-import form.DateMappings.requiredDateMapping
 import form.MappingSupport.turnoverSalesMapping
 import models.submissions.aboutthetradinghistory.TurnoverSection
 import play.api.data.{Form, Mapping}
-import play.api.data.Forms.{bigDecimal, mapping, number, optional}
+import play.api.data.Forms.{bigDecimal, mapping, number, optional, text}
 import play.api.data.validation.{Constraint, Invalid, Valid}
+
+import java.time.LocalDate
 
 object TurnoverForm {
 
@@ -32,10 +33,7 @@ object TurnoverForm {
         else Invalid("Average occupancy rate must be between 0 and 100")
     }
     def columnMapping: Mapping[TurnoverSection]            = mapping(
-      "financial-year-end"     -> requiredDateMapping(
-        allowFutureDates = true,
-        fieldErrorPart = ".financialYearEnd"
-      ),
+      "financial-year-end"     -> optional(text).transform[LocalDate](_ => LocalDate.EPOCH, _ => Some("")),
       "weeks"                  -> number(min = 0, max = 52),
       "alcoholic-drinks"       -> turnoverSalesMapping("turnover.alcohol.sales"),
       "food"                   -> turnoverSalesMapping("turnover.food.sales"),

--- a/app/views/aboutthetradinghistory/costOfSales.scala.html
+++ b/app/views/aboutthetradinghistory/costOfSales.scala.html
@@ -18,7 +18,10 @@
 @import models.submissions.aboutthetradinghistory.CostOfSales
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.Implicits._
+@import util.DateUtil
 @import util.NumberUtil._
+
+@import java.time.LocalDate
 
 @this(
         layout: Layout,
@@ -27,7 +30,8 @@
         govukInput: GovukInput,
         govukTable: GovukTable,
         govukInsetText: GovukInsetText,
-        govukDetails: GovukDetails
+        govukDetails: GovukDetails,
+        dateUtil: DateUtil
 )
 
 
@@ -38,13 +42,6 @@
     <p class="govuk-body govuk-!-font-weight-bold">@messages("costOfSales.details.h1")</p>
     <p class="govuk-body">@messages("costOfSales.details.p1")</p>
     <p class="govuk-body">@messages("costOfSales.details.p2")</p>
-}
-
-@financialYearEndContent(fieldName: String, form: Form[Seq[CostOfSales]]) = {
-@form(fieldName).value.map { endDate =>
-    @endDate
-    <input type="hidden" name="@fieldName" value="@endDate" />
-}
 }
 
 @accommodationHeading = {
@@ -79,7 +76,7 @@
 }
 
 @columns = @{
-    request.sessionData.aboutTheTradingHistory.map(_.costOfSales).fold(Seq.empty[Int])(_.indices)
+    request.sessionData.aboutTheTradingHistory.map(_.turnoverSections).fold(Seq.empty[Int])(_.indices)
 }
 
 @costInputAttributes = @{
@@ -117,10 +114,11 @@
                     content = Text(messages("costOfSales.financialYearEnd")),
                     classes = "govuk-!-font-weight-bold"
                 ) +:
-                        columns.map { idx =>
+                        request.sessionData.aboutTheTradingHistory
+                        .fold(Seq.empty[LocalDate])(_.turnoverSections.map(_.financialYearEnd)).map { finYearEnd =>
                             TableRow(
-                                content = HtmlContent(
-                                    financialYearEndContent(s"costOfSales[$idx].financial-year-end", form)
+                                content = Text(
+                                    dateUtil.formatDayMonthAbbrYear(finYearEnd)
                                 )
                             )
                         },

--- a/app/views/aboutthetradinghistory/financialYearEndDates.scala.html
+++ b/app/views/aboutthetradinghistory/financialYearEndDates.scala.html
@@ -44,7 +44,7 @@
 }
 
 @indices = @{
-    request.sessionData.aboutTheTradingHistory.map(_.turnoverSections).fold(Seq.empty[Int])(_.indices)
+    request.sessionData.aboutTheTradingHistory.fold(Seq.empty[Int])(_.turnoverSections.indices)
 }
 
 @layout(

--- a/app/views/aboutthetradinghistory/fixedOperatingExpenses.scala.html
+++ b/app/views/aboutthetradinghistory/fixedOperatingExpenses.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import models.pages.Summary
 @import java.time.LocalDate
+@import util.DateUtil._
 
 @this(layout: Layout,
         govukButton: GovukButton,
@@ -61,7 +62,7 @@
                                   govukInput(Input(
                                       id = s"$idx.financial-year-end",
                                       name = s"$idx.financial-year-end",
-                                      value = financialYears(idx).toString
+                                      value = financialYears(idx).shortDate
                                   ).withFormField(form(s"$idx.financial-year-end")))
                               )
                           )

--- a/app/views/aboutthetradinghistory/totalPayrollCosts.scala.html
+++ b/app/views/aboutthetradinghistory/totalPayrollCosts.scala.html
@@ -19,6 +19,7 @@
 @import models.pages.Summary
 @import java.time.LocalDate
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
+@import util.DateUtil._
 
 
 @this(layout: Layout,
@@ -64,7 +65,7 @@
                                   govukInput(Input(
                                       id = s"$idx.financial-year-end",
                                       name = s"$idx.financial-year-end",
-                                      value = financialYears(idx).toString
+                                      value = financialYears(idx).shortDate
                                   ).withFormField(form(s"$idx.financial-year-end")))
                               )
                           )

--- a/app/views/aboutthetradinghistory/turnover.scala.html
+++ b/app/views/aboutthetradinghistory/turnover.scala.html
@@ -18,6 +18,9 @@
 @import models.submissions.aboutthetradinghistory.TurnoverSection
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
+@import util.DateUtil
+
+@import java.time.LocalDate
 
 @this(layout: Layout,
         govukButton: GovukButton,
@@ -26,7 +29,8 @@
         govukDateInput: GovukDateInput,
         govukTable: GovukTable,
         govukInsetText: GovukInsetText,
-        govukDetails: GovukDetails
+        govukDetails: GovukDetails,
+        dateUtil: DateUtil
 )
 
 @(form: Form[Seq[TurnoverSection]])(implicit request: SessionRequest[_], messages: Messages)
@@ -38,10 +42,6 @@
     <p class="govuk-body govuk-!-font-weight-bold">@messages("turnover.details.h2")</p>
     <p class="govuk-body">@messages("turnover.details.p3")</p>
 
-}
-
-@financialYearEndContent(fieldName: String) = {
-    @includes.dateFields(form = form, field = fieldName, govukDate = govukDateInput, helpText = "", showDays = true, showFieldSet = false)
 }
 
 @alcoholicDrinksHeading = {
@@ -74,7 +74,7 @@
 }
 
 @columns = @{
-    request.sessionData.aboutTheTradingHistory.map(_.turnoverSections).fold(Seq.empty[Int])(_.indices)
+    request.sessionData.aboutTheTradingHistory.fold(Seq.empty[Int])(_.turnoverSections.indices)
 }
 
 @layout(
@@ -111,13 +111,14 @@
                   content = Text(messages("turnover.financialYearEnd")),
                   classes = "govuk-!-font-weight-bold"
               ) +:
-                  columns.map { idx  =>
-                  TableRow(
-                      content = HtmlContent(
-                          financialYearEndContent(s"$idx.financial-year-end")
-                      )
-                  )
-              },
+                      request.sessionData.aboutTheTradingHistory
+                      .fold(Seq.empty[LocalDate])(_.turnoverSections.map(_.financialYearEnd)).map { finYearEnd =>
+                          TableRow(
+                              content = Text(
+                                  dateUtil.formatDayMonthAbbrYear(finYearEnd)
+                              )
+                          )
+                      },
               TableRow(
                   content = Text(messages("turnover.tradingPeriod")),
                   classes = "govuk-!-font-weight-bold"

--- a/app/views/aboutthetradinghistory/variableOperatingExpenses.scala.html
+++ b/app/views/aboutthetradinghistory/variableOperatingExpenses.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import models.pages.Summary
 @import java.time.LocalDate
+@import util.DateUtil._
 
 @this(layout: Layout,
         govukButton: GovukButton,
@@ -65,7 +66,7 @@
                                   govukInput(Input(
                                       id = s"$idx.financial-year-end",
                                       name = s"$idx.financial-year-end",
-                                      value = financialYears(idx).toString
+                                      value = financialYears(idx).shortDate
                                   ).withFormField(form(s"$idx.financial-year-end")))
                               )
                           )

--- a/app/views/answers/answersAboutYourTradingHistory.scala.html
+++ b/app/views/answers/answersAboutYourTradingHistory.scala.html
@@ -17,6 +17,7 @@
 @import actions.SessionRequest
 @import controllers.aboutthetradinghistory
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import models.submissions.aboutthetradinghistory.CostOfSales
 @import models.submissions.aboutthetradinghistory.TurnoverSection
 @import util.DateUtil
 @import util.NumberUtil._
@@ -33,6 +34,10 @@
 
 @sectionAnswers = @{
     SectionAnswersRowBuilder(request.sessionData.aboutTheTradingHistory)
+}
+
+@forType = @{
+    request.sessionData.forType
 }
 
 @table(valuesGrid: Seq[Seq[String]]) = {
@@ -79,6 +84,30 @@
     ).mkString("""<p class="govuk-body govuk-!-font-weight-bold">""", """</p> <p class="govuk-body govuk-!-font-weight-bold">""", "</p>")
 }
 
+@costOfSalesValuesTable(costOfSales: Seq[CostOfSales]) = @{
+    table(
+        costOfSales.map(s => Seq(
+            dateUtil.formatDayMonthAbbrYear(s.financialYearEnd),
+            s.accommodation.getOrElse(zeroBigDecimal).asMoney,
+            s.drinks.getOrElse(zeroBigDecimal).asMoney,
+            s.food.getOrElse(zeroBigDecimal).asMoney,
+            s.other.getOrElse(zeroBigDecimal).asMoney,
+            s.total.asMoney
+        ))
+    ).body
+}
+
+@costOfSalesKeys = @{
+    Seq(
+        messages("checkYourAnswersAboutTheTradingHistory.financialYearEnd"),
+        messages("checkYourAnswersAboutTheTradingHistory.accommodation"),
+        messages("checkYourAnswersAboutTheTradingHistory.drinks"),
+        messages("checkYourAnswersAboutTheTradingHistory.food"),
+        messages("checkYourAnswersAboutTheTradingHistory.otherReceipts"),
+        messages("costOfSales.total"),
+    ).mkString("""<p class="govuk-body govuk-!-font-weight-bold">""", """</p> <p class="govuk-body govuk-!-font-weight-bold">""", "</p>")
+}
+
 <h2 class="govuk-heading-m">@messages("aboutYourTradingHistory.heading")</h2>
 
 @govukSummaryList(SummaryList(rows =
@@ -107,7 +136,10 @@
                         ActionItem(
                             href = s"${aboutthetradinghistory.routes.TurnoverController.show().url}?from=CYA",
                             content = Text(messages("label.change")),
-                            visuallyHiddenText = Some(messages("turnover.heading"))
+                            visuallyHiddenText = Some(messages("turnover.heading")),
+                            attributes = Map(
+                                "aria-label" -> s"${messages("label.change")} ${messages("turnover.heading")}"
+                            )
                         )
                     )
                 )
@@ -115,3 +147,30 @@
         )
     )
 ))
+
+@if(forType == ForTypes.for6015) {
+    <h2 class="govuk-heading-m">@messages("costOfSales.heading")</h2>
+
+    @govukSummaryList(SummaryList(rows =
+        Seq(
+            SummaryListRow(
+                key = Key(HtmlContent(costOfSalesKeys)),
+                value = Value(HtmlContent(sectionAnswers.answers.fold("")(t => costOfSalesValuesTable(t.costOfSales)))),
+                actions = Some(
+                    Actions(items =
+                        Seq(
+                            ActionItem(
+                                href = s"${aboutthetradinghistory.routes.CostOfSalesController.show().url}?from=CYA",
+                                content = Text(messages("label.change")),
+                                visuallyHiddenText = Some(messages("costOfSales.heading")),
+                                attributes = Map(
+                                    "aria-label" -> s"${messages("label.change")} ${messages("costOfSales.heading")}"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    ))
+}

--- a/test/views/aboutthetradinghistory/TurnoverViewSpec.scala
+++ b/test/views/aboutthetradinghistory/TurnoverViewSpec.scala
@@ -71,13 +71,6 @@ class TurnoverViewSpec extends QuestionViewBehaviours[Seq[TurnoverSection]] {
       assert(doc.toString.contains(messages("turnover.details.p3")))
     }
 
-    s"contain an input for financial-year-end" in {
-      val doc = asDocument(createView())
-      assertRenderedById(doc, "0.financial-year-end")
-      assertRenderedById(doc, "1.financial-year-end")
-      assertRenderedById(doc, "2.financial-year-end")
-    }
-
     s"contain an input for weeks" in {
       val doc = asDocument(createView())
       assertRenderedById(doc, "0.weeks")


### PR DESCRIPTION
- Show `financial-year-end` as readonly text instead of date field on `/turnover` form
- Updated 6015 `CostOfSalesController` to use the latest turnover session data structure
- Fixed 6015 specific Trading history journey pages by correct form initialization and correct date format on UI
- Redirect back to CYA if data for the next page is already completed
