### PR TITLE
BST-76814 Mapping for date fields with only 2 inputs [dd][mm] or [mm][yyyy]

### DIFF
--- a/app/assets/javascripts/responsive-table.js
+++ b/app/assets/javascripts/responsive-table.js
@@ -1,17 +1,17 @@
 function synchronizeRowsHeight() {
-    const govukTables = document.getElementsByClassName("govuk-table");
+    const govukTables = document.getElementsByClassName('govuk-table');
     const tablesCount = govukTables.length;
     const rowsHeight = [];
 
     if (tablesCount > 1 && screen.width > 800) {
         for (let t = 0; t < tablesCount; t++) {
-            const rows = govukTables[t].getElementsByTagName("tr");
+            const rows = govukTables[t].getElementsByTagName('tr');
             for (let r = 0; r < rows.length; r++) {
                 rowsHeight[r] = rowsHeight.length > r && rowsHeight[r] > rows[r].offsetHeight ? rowsHeight[r] : rows[r].offsetHeight;
             }
         }
         for (let t = 0; t < tablesCount; t++) {
-            const rows = govukTables[t].getElementsByTagName("tr");
+            const rows = govukTables[t].getElementsByTagName('tr');
             for (let r = 0; r < rows.length; r++) {
                 rows[r].style.height = rowsHeight[r] + 'px';
             }
@@ -21,4 +21,4 @@ function synchronizeRowsHeight() {
 
 synchronizeRowsHeight();
 
-window.addEventListener("resize", synchronizeRowsHeight);
+window.addEventListener('resize', synchronizeRowsHeight);

--- a/app/assets/javascripts/responsive-table.js
+++ b/app/assets/javascripts/responsive-table.js
@@ -7,7 +7,7 @@ function synchronizeRowsHeight() {
         for (let t = 0; t < tablesCount; t++) {
             const rows = govukTables[t].getElementsByTagName("tr");
             for (let r = 0; r < rows.length; r++) {
-                rowsHeight[r] = rowsHeight.length > r ? Math.max(rows[r].offsetHeight, rowsHeight[r]) : rows[r].offsetHeight;
+                rowsHeight[r] = rowsHeight.length > r && rowsHeight[r] > rows[r].offsetHeight ? rowsHeight[r] : rows[r].offsetHeight;
             }
         }
         for (let t = 0; t < tablesCount; t++) {

--- a/app/form/DateMappings.scala
+++ b/app/form/DateMappings.scala
@@ -16,14 +16,12 @@
 
 package form
 
-import form.Form6010.ConditionalMapping._
 import models.submissions.Form6010.{DayMonthsDuration, MonthsYearDuration}
 import play.api.data.Forms._
 import play.api.data.Mapping
 import play.api.i18n.Messages
 
 import java.time.LocalDate
-import scala.util.Try
 
 object DateMappings {
 
@@ -41,37 +39,10 @@ object DateMappings {
   )(implicit messages: Messages): Mapping[MonthsYearDuration] =
     of(new MonthYearFormatter(fieldNameKey, allowPastDates, allowFutureDates))
 
-  def isDayMonthValidDate(day: Int, month: Int): Boolean =
-    Try(LocalDate.of(LocalDate.now().getYear, month, day)).isSuccess
-
-  def dayMonthsDurationMapping(prefix: String, fieldErrorPart: String = ""): Mapping[DayMonthsDuration] = tuple(
-    "day"   -> nonEmptyTextOr(
-      prefix + ".day",
-      text.verifying(
-        Errors.invalidDurationDays,
-        x => x.trim.forall(Character.isDigit) && x.trim.toInt >= 0 && x.trim.toInt <= 31
-      ),
-      s"error$fieldErrorPart.day.required"
-    ),
-    "month" -> nonEmptyTextOr(
-      prefix + ".month",
-      text.verifying(
-        Errors.invalidDurationMonths,
-        x => x.trim.forall(Character.isDigit) && x.trim.toInt >= 0 && x.trim.toInt <= 12
-      ),
-      s"error$fieldErrorPart.month.required"
-    )
-  ).verifying(
-    "error.invalid_date",
-    formData => {
-      val (day, month) = (formData._1.trim.toInt, formData._2.trim.toInt)
-      isDayMonthValidDate(day, month)
-    }
-  ).transform(
-    { case (days, months) =>
-      DayMonthsDuration(days.trim.toInt, months.trim.toInt)
-    },
-    (my: DayMonthsDuration) => (my.days.toString, my.months.toString)
-  )
+  def dayMonthMapping(
+    fieldNameKey: String,
+    allow29February: Boolean = false
+  )(implicit messages: Messages): Mapping[DayMonthsDuration] =
+    of(new DayMonthFormatter(fieldNameKey, allow29February))
 
 }

--- a/app/form/DayMonthFormatter.scala
+++ b/app/form/DayMonthFormatter.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package form
+
+import models.submissions.Form6010.DayMonthsDuration
+import play.api.data.FormError
+import play.api.data.Forms._
+import play.api.data.format.Formatter
+import play.api.i18n.Messages
+
+import java.time.LocalDate
+import scala.collection.immutable.Seq
+import scala.util.Try
+
+/**
+  * Handles binding [dd] [mm] fields to DayMonthsDuration and unbinding DayMonthsDuration to [dd] [mm] fields.
+  *
+  * @author Yuriy Tumakha
+  */
+class DayMonthFormatter(
+  fieldNameKey: String,
+  allow29February: Boolean
+)(implicit messages: Messages)
+    extends Formatter[DayMonthsDuration] {
+
+  private val dayMonthFields = Seq("day", "month")
+  private val validationYear = if (allow29February) 2020 else 2021
+
+  override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], DayMonthsDuration] = {
+    val fieldName        = messages(s"fieldName.$fieldNameKey")
+    val fieldCapitalized = fieldName.capitalize
+    val dayText          = messages("error.dateParts.day")
+    val monthText        = messages("error.dateParts.month")
+    val dayKey           = s"$key.day"
+    val monthKey         = s"$key.month"
+
+    single(
+      key -> tuple(
+        "day"   -> optional(text),
+        "month" -> optional(text)
+      )
+    ).bind(data).flatMap {
+      case (None, None)       => oneError(dayKey, "error.date.required", Seq(fieldName, dayMonthFields))
+      case (None, Some(_))    =>
+        oneError(dayKey, "error.date.mustInclude", Seq(fieldCapitalized, dayText, Seq("day")))
+      case (Some(_), None)    =>
+        oneError(monthKey, "error.date.mustInclude", Seq(fieldCapitalized, monthText, Seq("month")))
+      case (Some(d), Some(m)) =>
+        val day   = parseNumber(d, 1 to 31)
+        val month = parseNumber(m, 1 to 12)
+        if (Seq(day, month).forall(_ > 0)) {
+          validateDayMonth(day, month).left.map { errorKey =>
+            Seq(FormError(dayKey, errorKey, Seq(fieldCapitalized, dayMonthFields)))
+          }
+        } else {
+          Left(
+            Seq(
+              Option.when(day == 0)(FormError(dayKey, "error.date.day.invalid")),
+              Option.when(month == 0)(FormError(monthKey, "error.date.month.invalid"))
+            ).flatten
+          )
+        }
+    }
+  }
+
+  override def unbind(key: String, value: DayMonthsDuration): Map[String, String] =
+    Map(
+      s"$key.day"   -> value.days.toString,
+      s"$key.month" -> value.months.toString
+    )
+
+  private def parseNumber(str: String, allowedRange: Range): Int =
+    Try(str.trim.toInt).filter(allowedRange.contains).getOrElse(0)
+
+  private def oneError(key: String, message: String, args: Seq[Any]): Left[Seq[FormError], DayMonthsDuration] =
+    Left(Seq(FormError(key, message, args)))
+
+  private def validateDayMonth(day: Int, month: Int): Either[String, DayMonthsDuration] =
+    Try(LocalDate.of(validationYear, month, day)).toEither.left
+      .map(_ => "error.date.invalid")
+      .map(_ => DayMonthsDuration(day, month))
+
+}

--- a/app/form/LocalDateFormatter.scala
+++ b/app/form/LocalDateFormatter.scala
@@ -54,9 +54,9 @@ class LocalDateFormatter(
     ).bind(data).flatMap {
       case (None, None, None)          => oneError(dayKey, "error.date.required", Seq(fieldName, allDateFields))
       case (Some(d), Some(m), Some(y)) =>
-        val day          = Try(d.trim.toInt).filter((1 to 31).contains(_)).getOrElse(0)
-        val month        = Try(m.trim.toInt).filter((1 to 12).contains(_)).getOrElse(0)
-        val year         = Try(y.trim.toInt).filter(_ > 0).getOrElse(0)
+        val day          = Try(d.trim.toInt).filter((1 to 31) contains _).getOrElse(0)
+        val month        = Try(m.trim.toInt).filter((1 to 12) contains _).getOrElse(0)
+        val year         = Try(y.trim.toInt).filter((1000 to 9999) contains _).getOrElse(0)
         val datePartsSeq = Seq(day, month, year)
         if (datePartsSeq.forall(_ > 0)) {
           validateDate(day, month, year).left.map { errorKey =>

--- a/app/form/LocalDateFormatter.scala
+++ b/app/form/LocalDateFormatter.scala
@@ -52,31 +52,32 @@ class LocalDateFormatter(
         "year"  -> optional(text)
       )
     ).bind(data).flatMap {
-      case (None, None, None)          => Left(Seq(FormError(dayKey, "error.date.required", Seq(fieldName, allDateFields))))
+      case (None, None, None)          => oneError(dayKey, "error.date.required", Seq(fieldName, allDateFields))
       case (Some(d), Some(m), Some(y)) =>
         val day          = Try(d.trim.toInt).filter((1 to 31).contains(_)).getOrElse(0)
         val month        = Try(m.trim.toInt).filter((1 to 12).contains(_)).getOrElse(0)
         val year         = Try(y.trim.toInt).filter(_ > 0).getOrElse(0)
         val datePartsSeq = Seq(day, month, year)
         if (datePartsSeq.forall(_ > 0)) {
-          validateDate(day, month, year, allowFutureDates).left.map { errorKey =>
+          validateDate(day, month, year).left.map { errorKey =>
             Seq(FormError(dayKey, errorKey, Seq(fieldNameCapitalized, allDateFields)))
           }
         } else {
           val invalidFields = (datePartsSeq zip allDateFields).filter(_._1 == 0).map(_._2)
           val focusKey      = s"$key.${invalidFields.head}"
-          Left(Seq(FormError(focusKey, "error.date.invalid", Seq(fieldNameCapitalized, invalidFields))))
+          oneError(focusKey, "error.date.invalid", Seq(fieldNameCapitalized, invalidFields))
         }
       case (d, m, y)                   =>
-        val prefix       = messages("error.dateParts.prefix")
-        val separator    = messages("error.dateParts.separator")
-        val dayText      = messages("error.dateParts.day")
-        val monthText    = messages("error.dateParts.month")
-        val yearText     = messages("error.dateParts.year")
-        val missedFields = (Seq(d, m, y) zip Seq(dayText, monthText, yearText)).filter(_._1.isEmpty).map(_._2)
-        val arg1         = missedFields.mkString(s"$prefix ", s" $separator ", "")
-        val focusKey     = s"$key.${missedFields.head}"
-        Left(Seq(FormError(focusKey, "error.date.mustInclude", Seq(fieldNameCapitalized, arg1, missedFields))))
+        val prefix           = messages("error.dateParts.prefix")
+        val separator        = messages("error.dateParts.separator")
+        val dayText          = messages("error.dateParts.day")
+        val monthText        = messages("error.dateParts.month")
+        val yearText         = messages("error.dateParts.year")
+        val missedFields     = (Seq(d, m, y) zip allDateFields).filter(_._1.isEmpty).map(_._2)
+        val missedFieldsText = (Seq(d, m, y) zip Seq(dayText, monthText, yearText)).filter(_._1.isEmpty).map(_._2)
+        val arg1             = missedFieldsText.mkString(s"$prefix ", s" $separator ", "")
+        val focusKey         = s"$key.${missedFields.head}"
+        oneError(focusKey, "error.date.mustInclude", Seq(fieldNameCapitalized, arg1, missedFields))
     }
   }
 
@@ -87,7 +88,10 @@ class LocalDateFormatter(
       s"$key.year"  -> value.getYear.toString
     )
 
-  private def validateDate(day: Int, month: Int, year: Int, allowFutureDates: Boolean): Either[String, LocalDate] =
+  private def oneError(key: String, message: String, args: Seq[Any]): Left[Seq[FormError], LocalDate] =
+    Left(Seq(FormError(key, message, args)))
+
+  private def validateDate(day: Int, month: Int, year: Int): Either[String, LocalDate] =
     Try(LocalDate.of(year, month, day)).toEither.left
       .map(_ => "error.date.invalid")
       .flatMap { date =>

--- a/app/form/LocalDateFormatter.scala
+++ b/app/form/LocalDateFormatter.scala
@@ -54,9 +54,9 @@ class LocalDateFormatter(
     ).bind(data).flatMap {
       case (None, None, None)          => oneError(dayKey, "error.date.required", Seq(fieldName, allDateFields))
       case (Some(d), Some(m), Some(y)) =>
-        val day          = Try(d.trim.toInt).filter((1 to 31) contains _).getOrElse(0)
-        val month        = Try(m.trim.toInt).filter((1 to 12) contains _).getOrElse(0)
-        val year         = Try(y.trim.toInt).filter((1000 to 9999) contains _).getOrElse(0)
+        val day          = parseNumber(d, 1 to 31)
+        val month        = parseNumber(m, 1 to 12)
+        val year         = parseNumber(y, 1000 to 9999)
         val datePartsSeq = Seq(day, month, year)
         if (datePartsSeq.forall(_ > 0)) {
           validateDate(day, month, year).left.map { errorKey =>
@@ -87,6 +87,9 @@ class LocalDateFormatter(
       s"$key.month" -> value.getMonthValue.toString,
       s"$key.year"  -> value.getYear.toString
     )
+
+  private def parseNumber(str: String, allowedRange: Range): Int =
+    Try(str.trim.toInt).filter(allowedRange.contains).getOrElse(0)
 
   private def oneError(key: String, message: String, args: Seq[Any]): Left[Seq[FormError], LocalDate] =
     Left(Seq(FormError(key, message, args)))

--- a/app/form/MonthYearFormatter.scala
+++ b/app/form/MonthYearFormatter.scala
@@ -61,8 +61,8 @@ class MonthYearFormatter(
       case (Some(_), None)    =>
         oneError(yearKey, "error.date.mustInclude", Seq(fieldCapitalized, yearText, Seq("year")))
       case (Some(m), Some(y)) =>
-        val month = Try(m.trim.toInt).filter((1 to 12) contains _).getOrElse(0)
-        val year  = Try(y.trim.toInt).filter((1900 to 9999) contains _).getOrElse(0)
+        val month = parseNumber(m, 1 to 12)
+        val year  = parseNumber(y, 1900 to 9999)
         if (Seq(month, year).forall(_ > 0)) {
           validateDate(month, year).left.map { errorKey =>
             Seq(FormError(monthKey, errorKey, Seq(fieldCapitalized, monthYearFields)))
@@ -83,6 +83,9 @@ class MonthYearFormatter(
       s"$key.month" -> value.months.toString,
       s"$key.year"  -> value.years.toString
     )
+
+  private def parseNumber(str: String, allowedRange: Range): Int =
+    Try(str.trim.toInt).filter(allowedRange.contains).getOrElse(0)
 
   private def oneError(key: String, message: String, args: Seq[Any]): Left[Seq[FormError], MonthsYearDuration] =
     Left(Seq(FormError(key, message, args)))

--- a/app/form/MonthYearFormatter.scala
+++ b/app/form/MonthYearFormatter.scala
@@ -61,8 +61,8 @@ class MonthYearFormatter(
       case (Some(_), None)    =>
         oneError(yearKey, "error.date.mustInclude", Seq(fieldCapitalized, yearText, Seq("year")))
       case (Some(m), Some(y)) =>
-        val month = Try(m.trim.toInt).filter((1 to 12).contains(_)).getOrElse(0)
-        val year  = Try(y.trim.toInt).filter(_ >= 1900).getOrElse(0)
+        val month = Try(m.trim.toInt).filter((1 to 12) contains _).getOrElse(0)
+        val year  = Try(y.trim.toInt).filter((1900 to 9999) contains _).getOrElse(0)
         if (Seq(month, year).forall(_ > 0)) {
           validateDate(month, year).left.map { errorKey =>
             Seq(FormError(monthKey, errorKey, Seq(fieldCapitalized, monthYearFields)))

--- a/app/form/MonthYearFormatter.scala
+++ b/app/form/MonthYearFormatter.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package form
+
+import models.submissions.Form6010.MonthsYearDuration
+import play.api.data.FormError
+import play.api.data.Forms._
+import play.api.data.format.Formatter
+import play.api.i18n.Messages
+import util.DateUtil.nowInUK
+
+import java.time.LocalDate
+import scala.collection.immutable.Seq
+import scala.util.Try
+
+/**
+  * Handles binding [mm] [yyyy] fields to MonthsYearDuration and unbinding MonthsYearDuration to [mm] [yyyy] fields.
+  *
+  * @author Yuriy Tumakha
+  */
+class MonthYearFormatter(
+  fieldNameKey: String,
+  allowPastDates: Boolean,
+  allowFutureDates: Boolean
+)(implicit messages: Messages)
+    extends Formatter[MonthsYearDuration] {
+
+  private val monthYearFields = Seq("month", "year")
+
+  override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], MonthsYearDuration] = {
+    val fieldName        = messages(s"fieldName.$fieldNameKey")
+    val fieldCapitalized = fieldName.capitalize
+    val monthText        = messages("error.dateParts.month")
+    val yearText         = messages("error.dateParts.year")
+    val monthKey         = s"$key.month"
+    val yearKey          = s"$key.year"
+
+    single(
+      key -> tuple(
+        "month" -> optional(text),
+        "year"  -> optional(text)
+      )
+    ).bind(data).flatMap {
+      case (None, None)       => oneError(monthKey, "error.date.required", Seq(fieldName, monthYearFields))
+      case (None, Some(_))    =>
+        oneError(monthKey, "error.date.mustInclude", Seq(fieldCapitalized, monthText, Seq("month")))
+      case (Some(_), None)    =>
+        oneError(yearKey, "error.date.mustInclude", Seq(fieldCapitalized, yearText, Seq("year")))
+      case (Some(m), Some(y)) =>
+        val month = Try(m.trim.toInt).filter((1 to 12).contains(_)).getOrElse(0)
+        val year  = Try(y.trim.toInt).filter(_ >= 1900).getOrElse(0)
+        if (Seq(month, year).forall(_ > 0)) {
+          validateDate(month, year).left.map { errorKey =>
+            Seq(FormError(monthKey, errorKey, Seq(fieldCapitalized, monthYearFields)))
+          }
+        } else {
+          Left(
+            Seq(
+              Option.when(month == 0)(FormError(monthKey, "error.date.month.invalid")),
+              Option.when(year == 0)(FormError(yearKey, "error.date.year.invalid", Seq(fieldCapitalized)))
+            ).flatten
+          )
+        }
+    }
+  }
+
+  override def unbind(key: String, value: MonthsYearDuration): Map[String, String] =
+    Map(
+      s"$key.month" -> value.months.toString,
+      s"$key.year"  -> value.years.toString
+    )
+
+  private def oneError(key: String, message: String, args: Seq[Any]): Left[Seq[FormError], MonthsYearDuration] =
+    Left(Seq(FormError(key, message, args)))
+
+  private def validateDate(month: Int, year: Int): Either[String, MonthsYearDuration] =
+    Try(LocalDate.of(year, month, 1)).toEither.left
+      .map(_ => "error.date.invalid")
+      .flatMap { date =>
+        val today        = nowInUK.toLocalDate
+        val startOfMonth = LocalDate.of(today.getYear, today.getMonthValue, 1)
+
+        if (!allowPastDates && date.isBefore(startOfMonth)) {
+          Left("error.date.beforeToday")
+        } else if (!allowFutureDates && date.isAfter(startOfMonth)) {
+          Left("error.date.mustBeInPast")
+        } else {
+          Right(MonthsYearDuration(date.getMonthValue, date.getYear))
+        }
+      }
+
+}

--- a/app/form/aboutYourLeaseOrTenure/CurrentLeaseOrAgreementBeginForm.scala
+++ b/app/form/aboutYourLeaseOrTenure/CurrentLeaseOrAgreementBeginForm.scala
@@ -16,20 +16,22 @@
 
 package form.aboutYourLeaseOrTenure
 
-import form.DateMappings.monthsYearDurationMapping
+import form.DateMappings.monthYearMapping
 import models.submissions.aboutYourLeaseOrTenure.CurrentLeaseOrAgreementBegin
 import play.api.data.Form
 import play.api.data.Forms.{default, mapping, text}
 import play.api.data.validation.Constraints.nonEmpty
+import play.api.i18n.Messages
 
 object CurrentLeaseOrAgreementBeginForm {
 
-  val currentLeaseOrAgreementBeginForm = Form(
+  def currentLeaseOrAgreementBeginForm(implicit messages: Messages): Form[CurrentLeaseOrAgreementBegin] = Form(
     mapping(
-      "leaseBegin" -> monthsYearDurationMapping("leaseBegin", ".leaseBegin"),
+      "leaseBegin" -> monthYearMapping("leaseBegin", allowPastDates = true),
       "grantedFor" -> default(text, "").verifying(
         nonEmpty(errorMessage = "error.grantedFor.required")
       )
     )(CurrentLeaseOrAgreementBegin.apply)(CurrentLeaseOrAgreementBegin.unapply)
   )
+
 }

--- a/app/form/aboutthetradinghistory/AccountingInformationForm.scala
+++ b/app/form/aboutthetradinghistory/AccountingInformationForm.scala
@@ -16,18 +16,19 @@
 
 package form.aboutthetradinghistory
 
-import form.DateMappings.dayMonthsDurationMapping
+import form.DateMappings.dayMonthMapping
 import models.submissions.Form6010.DayMonthsDuration
 import play.api.data.Form
 import play.api.data.Forms.{optional, text, tuple}
+import play.api.i18n.Messages
 
 object AccountingInformationForm {
 
-  val accountingInformationForm: Form[(DayMonthsDuration, Boolean)] = Form(
+  def accountingInformationForm(implicit messages: Messages): Form[(DayMonthsDuration, Boolean)] = Form(
     tuple(
-      "financialYear"  -> dayMonthsDurationMapping("financialYear", ".financialYear"),
+      "financialYear"  -> dayMonthMapping("financialYear", allow29February = false),
       "yearEndChanged" -> optional(text)
-        .transform[Boolean](_.exists(_.equals("true")), b => Some(b.toString))
+        .transform[Boolean](_.contains("true"), b => Some(b.toString))
     )
   )
 

--- a/app/form/aboutthetradinghistory/OccupationalInformationForm.scala
+++ b/app/form/aboutthetradinghistory/OccupationalInformationForm.scala
@@ -16,16 +16,17 @@
 
 package form.aboutthetradinghistory
 
-import form.DateMappings.monthsYearDurationMapping
+import form.DateMappings.monthYearMapping
 import models.submissions.Form6010.MonthsYearDuration
 import play.api.data.Form
 import play.api.data.Forms._
+import play.api.i18n.Messages
 
 object OccupationalInformationForm {
 
-  val occupationalInformationForm: Form[MonthsYearDuration] = Form(
+  def occupationalInformationForm(implicit messages: Messages): Form[MonthsYearDuration] = Form(
     single(
-      "firstOccupy" -> monthsYearDurationMapping("firstOccupy", ".firstOccupy")
+      "firstOccupy" -> monthYearMapping("firstOccupy", allowPastDates = true)
     )
   )
 

--- a/app/models/submissions/Form6010/DayMonthsDuration.scala
+++ b/app/models/submissions/Form6010/DayMonthsDuration.scala
@@ -20,8 +20,11 @@ import play.api.libs.json.Json
 
 import java.time.MonthDay
 
+/**
+  * Represents dd/mm part of Date.
+  */
 case class DayMonthsDuration(days: Int, months: Int) {
-  def toMonthDay = MonthDay.of(months, days)
+  def toMonthDay: MonthDay = MonthDay.of(months, days)
 }
 
 object DayMonthsDuration {

--- a/app/models/submissions/Form6010/MonthsYearDuration.scala
+++ b/app/models/submissions/Form6010/MonthsYearDuration.scala
@@ -20,8 +20,11 @@ import play.api.libs.json.Json
 
 import java.time.YearMonth
 
+/**
+  * Represents mm/yyyy part of Date.
+  */
 case class MonthsYearDuration(months: Int, years: Int) {
-  def toYearMonth = YearMonth.of(years, months)
+  def toYearMonth: YearMonth = YearMonth.of(years, months)
 }
 
 object MonthsYearDuration {

--- a/app/uk.gov.voa.play.form/ConditionalMappings.scala
+++ b/app/uk.gov.voa.play.form/ConditionalMappings.scala
@@ -93,8 +93,7 @@ object ConditionalMappings {
     pairs: Seq[(String, String)],
     mapping: Mapping[T]
   ): Mapping[Option[T]] = {
-    val condition: Condition = x =>
-      (for (pair <- pairs) yield x.get(pair._1).contains(pair._2)).count(identity) > 0
+    val condition: Condition = x => (for (pair <- pairs) yield x.get(pair._1).contains(pair._2)).count(identity) > 0
     ConditionalMapping(condition, MandatoryOptionalMapping(mapping, Nil), None, Seq.empty)
   }
 

--- a/app/uk.gov.voa.play.form/ConditionalMappings.scala
+++ b/app/uk.gov.voa.play.form/ConditionalMappings.scala
@@ -94,7 +94,7 @@ object ConditionalMappings {
     mapping: Mapping[T]
   ): Mapping[Option[T]] = {
     val condition: Condition = x =>
-      (for (pair <- pairs) yield x.get(pair._1).contains(pair._2)).count(b => b.equals(true)) > 0
+      (for (pair <- pairs) yield x.get(pair._1).contains(pair._2)).count(identity) > 0
     ConditionalMapping(condition, MandatoryOptionalMapping(mapping, Nil), None, Seq.empty)
   }
 

--- a/conf/messages
+++ b/conf/messages
@@ -955,8 +955,7 @@ label.financialYear = When does your current financial year end?
 financialYearEnd.yearEndChanged.legend = If your financial year end has changed
 financialYearEnd.yearEndChanged.hint = Use the checkbox if your financial year end has changed in the last 3 years. You will be taken to a separate page to declare the former year-end dates.
 financialYearEnd.yearEndChanged = My financial year end has changed in the last three years.
-error.financialYear.day.required = The date the financial years ends must include a day
-error.financialYear.month.required = The date the financial years ends must include a month
+fieldName.financialYear = the date the financial years ends
 
 # FINANCIAL YEAR-END DATES
 ##############################

--- a/conf/messages
+++ b/conf/messages
@@ -946,8 +946,7 @@ error.legalOrPlanningRestrictionsDetails.maxLength = The description of the othe
 ##############################
 aboutYourTradingHistory.heading = Occupation and accounting information
 firstOccupy.heading = When did you first occupy the property?
-error.firstOccupy.month.required = The date the property was first occupied must include a month
-error.firstOccupy.year.required = The date the property was first occupied must include a year
+fieldName.firstOccupy = the date the property was first occupied
 
 # FINANCIAL YEAR-END
 ##############################
@@ -990,8 +989,7 @@ label.currentLeaseOrAgreementBegin = If the current lease was originally assigne
 label.grantedFor = How long was it granted for?
 hint.currentLeaseOrAgreementBegin = For example, 18 months, 1.5 years, or 1 year and 6 months.
 error.grantedFor.required = Enter the length of the current lease
-error.leaseBegin.month.required = The date the current lease began must include a month
-error.leaseBegin.year.required = The date the current lease began must include a year
+fieldName.leaseBegin = the date the current lease began
 label.currentLeaseOrAgreementBegin.help = For example, 9 2017.
 
 # INTERVALS OF RENT REVIEW
@@ -1568,9 +1566,14 @@ error.tiedType.required = Select which type of tie you have
 error.addressLineTwo.maxLength = Address line 2 must be 50 characters or fewer
 error.townCity.maxLength = Town or city name must be 50 characters or fewer
 error.county.maxLength = County name must be 50 characters or fewer
+
+# Date fields validation
 error.date.required = Enter {0}
 error.date.mustInclude = {0} must include {1}
 error.date.invalid = {0} must be a real date
+error.date.day.invalid = The day figure must be a number between 1 and 31
+error.date.month.invalid = The month figure must be a number between 1 and 12
+error.date.year.invalid = {0} must be on or after January 1900
 error.date.before1900 = {0} must be on or after 1 January 1900
 error.date.beforeToday = {0} cannot be in the past
 error.date.mustBeInPast = {0} must be today or in the past

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -955,8 +955,7 @@ label.financialYear = When does your current financial year end?
 financialYearEnd.yearEndChanged.legend = If your financial year end has changed
 financialYearEnd.yearEndChanged.hint = Use the checkbox if your financial year end has changed in the last 3 years. You will be taken to a separate page to declare the former year-end dates.
 financialYearEnd.yearEndChanged = My financial year end has changed in the last three years.
-error.financialYear.day.required = The date the financial years ends must include a day
-error.financialYear.month.required = The date the financial years ends must include a month
+fieldName.financialYear = the date the financial years ends
 
 # FINANCIAL YEAR-END DATES
 ##############################

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -946,8 +946,7 @@ error.legalOrPlanningRestrictionsDetails.maxLength = The description of the othe
 ##############################
 aboutYourTradingHistory.heading = Occupation and accounting information
 firstOccupy.heading = When did you first occupy the property?
-error.firstOccupy.month.required = The date the property was first occupied must include a month
-error.firstOccupy.year.required = The date the property was first occupied must include a year
+fieldName.firstOccupy = the date the property was first occupied
 
 # FINANCIAL YEAR-END
 ##############################
@@ -990,8 +989,7 @@ label.currentLeaseOrAgreementBegin = If the current lease was originally assigne
 label.grantedFor = How long was it granted for?
 hint.currentLeaseOrAgreementBegin = For example, 18 months, 1.5 years, or 1 year and 6 months.
 error.grantedFor.required = Enter the length of the current lease
-error.leaseBegin.month.required = The date the current lease began must include a month
-error.leaseBegin.year.required = The date the current lease began must include a year
+fieldName.leaseBegin = the date the current lease began
 label.currentLeaseOrAgreementBegin.help = For example, 9 2017.
 
 # INTERVALS OF RENT REVIEW
@@ -1564,9 +1562,13 @@ error.tiedType.required = Select which type of tie you have
 error.addressLineTwo.maxLength = Address line 2 must be 50 characters or fewer
 error.county.maxLength = County name must be 50 characters or fewer
 
+# Date fields validation
 error.date.required = Enter {0}
 error.date.mustInclude = {0} must include {1}
 error.date.invalid = {0} must be a real date
+error.date.day.invalid = The day figure must be a number between 1 and 31
+error.date.month.invalid = The month figure must be a number between 1 and 12
+error.date.year.invalid = {0} must be on or after January 1900
 error.date.before1900 = {0} must be on or after 1 January 1900
 error.date.beforeToday = {0} cannot be in the past
 error.date.mustBeInPast = {0} must be today or in the past

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
 
   val bootstrapVersion     = "7.23.0"
   val playFrontendVersion  = "7.27.0-play-28"
-  val mongoVersion         = "1.3.0"
+  val mongoVersion         = "1.4.0"
   val cryptoJsonVersion    = "7.6.0"
   val jodaVersion          = "2.9.4"
   val cachingClientVersion = "10.0.0-play-28"

--- a/test/controllers/aboutthetradinghistory/AboutYourTradingHistoryControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/AboutYourTradingHistoryControllerSpec.scala
@@ -59,18 +59,25 @@ class AboutYourTradingHistoryControllerSpec extends TestBaseSpec {
   }
 
   "About your trading history form" should {
+    "error if first occupy month and year are missing " in {
+      val formData = baseFormData - errorKey.occupyMonth - errorKey.occupyYear
+      val form     = occupationalInformationForm(messages).bind(formData)
+
+      mustContainError(errorKey.occupyMonth, "error.date.required", form)
+    }
+
     "error if first occupy month is missing " in {
       val formData = baseFormData - errorKey.occupyMonth
-      val form     = occupationalInformationForm.bind(formData)
+      val form     = occupationalInformationForm(messages).bind(formData)
 
-      mustContainError(errorKey.occupyMonth, "error.firstOccupy.month.required", form)
+      mustContainError(errorKey.occupyMonth, "error.date.mustInclude", form)
     }
 
     "error if first occupy year is missing" in {
       val formData = baseFormData - errorKey.occupyYear
-      val form     = occupationalInformationForm.bind(formData)
+      val form     = occupationalInformationForm(messages).bind(formData)
 
-      mustContainError(errorKey.occupyYear, "error.firstOccupy.year.required", form)
+      mustContainError(errorKey.occupyYear, "error.date.mustInclude", form)
     }
   }
 

--- a/test/controllers/aboutthetradinghistory/FinancialYearEndControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/FinancialYearEndControllerSpec.scala
@@ -59,25 +59,46 @@ class FinancialYearEndControllerSpec extends TestBaseSpec {
   }
 
   "Financial year end form" should {
+    "error if financial year end day and month are missing " in {
+      val formData = baseFormData - errorKey.financialYearDay - errorKey.financialYearMonth
+      val form     = accountingInformationForm(messages).bind(formData)
+
+      mustContainError(errorKey.financialYearDay, "error.date.required", form)
+    }
+
     "error if financial year day is missing " in {
       val formData = baseFormData - errorKey.financialYearDay
-      val form     = accountingInformationForm.bind(formData)
+      val form     = accountingInformationForm(messages).bind(formData)
 
-      mustContainError(errorKey.financialYearDay, "error.financialYear.day.required", form)
+      mustContainError(errorKey.financialYearDay, "error.date.mustInclude", form)
     }
 
     "error if financial year month is missing" in {
       val formData = baseFormData - errorKey.financialYearMonth
-      val form     = accountingInformationForm.bind(formData)
+      val form     = accountingInformationForm(messages).bind(formData)
 
-      mustContainError(errorKey.financialYearMonth, "error.financialYear.month.required", form)
+      mustContainError(errorKey.financialYearMonth, "error.date.mustInclude", form)
     }
 
     "error if financial year date is incorrect" in {
       val formData = baseFormData.updated("financialYear.day", "31").updated("financialYear.month", "2")
-      val form     = accountingInformationForm.bind(formData)
+      val form     = accountingInformationForm(messages).bind(formData)
 
-      mustContainError("financialYear", "error.invalid_date", form)
+      mustContainError(errorKey.financialYearDay, "error.date.invalid", form)
+    }
+
+    "error if financial year day is incorrect" in {
+      val formData = baseFormData.updated("financialYear.day", "32")
+      val form     = accountingInformationForm(messages).bind(formData)
+
+      mustContainError(errorKey.financialYearDay, "error.date.day.invalid", form)
+    }
+
+    "error if financial year month is incorrect" in {
+      val formData = baseFormData.updated("financialYear.month", "13")
+      val form     = accountingInformationForm(messages).bind(formData)
+
+      mustContainError(errorKey.financialYearMonth, "error.date.month.invalid", form)
     }
   }
 

--- a/test/views/aboutYourLeaseOrTenure/CurrentLeaseOrAgreementBeginViewSpec.scala
+++ b/test/views/aboutYourLeaseOrTenure/CurrentLeaseOrAgreementBeginViewSpec.scala
@@ -27,7 +27,7 @@ class CurrentLeaseOrAgreementBeginViewSpec extends QuestionViewBehaviours[Curren
 
   val messageKeyPrefix = "currentLeaseOrAgreementBegin"
 
-  override val form = CurrentLeaseOrAgreementBeginForm.currentLeaseOrAgreementBeginForm
+  override val form = CurrentLeaseOrAgreementBeginForm.currentLeaseOrAgreementBeginForm(messages)
 
   def createView = () => currentLeaseOrAgreementBeginView(form, Summary("99996010001"))(fakeRequest, messages)
 

--- a/test/views/aboutthetradinghistory/AboutYourTradingHistoryViewSpec.scala
+++ b/test/views/aboutthetradinghistory/AboutYourTradingHistoryViewSpec.scala
@@ -31,7 +31,7 @@ class AboutYourTradingHistoryViewSpec extends QuestionViewBehaviours[MonthsYearD
   val sessionRequest = SessionRequest(aboutYourTradingHistory6010YesSession, fakeRequest)
 
   override val form: Form[MonthsYearDuration] =
-    OccupationalInformationForm.occupationalInformationForm
+    OccupationalInformationForm.occupationalInformationForm(messages)
 
   def createView: () => Html = () => aboutYourTradingHistoryView(form)(sessionRequest, messages)
 

--- a/test/views/aboutthetradinghistory/FinancialYearEndViewSpec.scala
+++ b/test/views/aboutthetradinghistory/FinancialYearEndViewSpec.scala
@@ -30,7 +30,7 @@ class FinancialYearEndViewSpec extends QuestionViewBehaviours[(DayMonthsDuration
 
   val sessionRequest = SessionRequest(aboutYourTradingHistory6010YesSession, fakeRequest)
 
-  override val form: Form[(DayMonthsDuration, Boolean)] = accountingInformationForm
+  override val form: Form[(DayMonthsDuration, Boolean)] = accountingInformationForm(messages)
 
   def createView: () => Html = () => financialYearEndView(form)(sessionRequest, messages)
 


### PR DESCRIPTION
- Created `MonthYearFormatter` to validate date fields with only 2 inputs `[mm][yyyy]`
- Created `DayMonthFormatter` to validate date fields with only 2 inputs `[dd][mm]`