### PR TITLE
BST-88432 6020 `/included in rent` new page & updated related navigation

### DIFF
--- a/app/controllers/aboutYourLeaseOrTenure/IncludedInRent6020Controller.scala
+++ b/app/controllers/aboutYourLeaseOrTenure/IncludedInRent6020Controller.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.aboutYourLeaseOrTenure
+
+import actions.{SessionRequest, WithSessionRefiner}
+import controllers.FORDataCaptureController
+import form.aboutYourLeaseOrTenure.IncludedInRent6020Form.includedInRent6020Form
+import models.submissions.aboutYourLeaseOrTenure.AboutLeaseOrAgreementPartOne.updateAboutLeaseOrAgreementPartOne
+import models.submissions.aboutYourLeaseOrTenure.{AboutLeaseOrAgreementPartOne, DoesTheRentPayable}
+import models.submissions.common.AnswerYes
+import navigation.AboutYourLeaseOrTenureNavigator
+import navigation.identifiers.IncludedInRent6020Id
+import play.api.Logging
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepo
+import views.html.aboutYourLeaseOrTenure.includedInRent6020
+
+import javax.inject.{Inject, Named, Singleton}
+import scala.concurrent.ExecutionContext
+
+/**
+  * @author Yuriy Tumakha
+  */
+@Singleton
+class IncludedInRent6020Controller @Inject() (
+  includedInRent6020View: includedInRent6020,
+  navigator: AboutYourLeaseOrTenureNavigator,
+  withSessionRefiner: WithSessionRefiner,
+  @Named("session") val session: SessionRepo,
+  mcc: MessagesControllerComponents
+)(implicit ec: ExecutionContext)
+    extends FORDataCaptureController(mcc)
+    with I18nSupport
+    with Logging {
+
+  def show: Action[AnyContent] = (Action andThen withSessionRefiner).async { implicit request =>
+    Ok(
+      includedInRent6020View(
+        leaseOrAgreementPartOne
+          .flatMap(_.doesTheRentPayable)
+          .fold(includedInRent6020Form)(includedInRent6020Form.fill),
+        getBackLink
+      )
+    )
+  }
+
+  def submit: Action[AnyContent] = (Action andThen withSessionRefiner).async { implicit request =>
+    continueOrSaveAsDraft[DoesTheRentPayable](
+      includedInRent6020Form,
+      formWithErrors => BadRequest(includedInRent6020View(formWithErrors, getBackLink)),
+      data => {
+        val updatedData = updateAboutLeaseOrAgreementPartOne(_.copy(doesTheRentPayable = Some(data)))
+
+        session.saveOrUpdate(updatedData).map { _ =>
+          Redirect(navigator.nextPage(IncludedInRent6020Id, updatedData).apply(updatedData))
+        }
+      }
+    )
+  }
+
+  private def leaseOrAgreementPartOne(implicit
+    request: SessionRequest[AnyContent]
+  ): Option[AboutLeaseOrAgreementPartOne] = request.sessionData.aboutLeaseOrAgreementPartOne
+
+  private def getBackLink(implicit request: SessionRequest[AnyContent]): String =
+    if (
+      request.sessionData.aboutLeaseOrAgreementPartOne
+        .flatMap(_.rentIncludeFixturesAndFittingsDetails)
+        .map(_.rentIncludeFixturesAndFittingsDetails)
+        .contains(AnswerYes)
+    ) {
+      controllers.aboutYourLeaseOrTenure.routes.RentedEquipmentDetailsController.show().url
+    } else {
+      controllers.aboutYourLeaseOrTenure.routes.RentIncludeFixtureAndFittingsController.show().url
+    }
+
+}

--- a/app/controllers/aboutYourLeaseOrTenure/RentOpenMarketValueController.scala
+++ b/app/controllers/aboutYourLeaseOrTenure/RentOpenMarketValueController.scala
@@ -86,14 +86,17 @@ class RentOpenMarketValueController @Inject() (
           case Some(AnswerYes) =>
             answers.forType match {
               case ForTypes.for6020 =>
-                controllers.aboutYourLeaseOrTenure.routes.RentedEquipmentDetailsController
-                  .show()
-                  .url // TODO: Does rent include the following
+                controllers.aboutYourLeaseOrTenure.routes.IncludedInRent6020Controller.show().url
               case _                =>
                 controllers.aboutYourLeaseOrTenure.routes.RentIncludeFixtureAndFittingsDetailsController.show().url
             }
           case _               =>
-            controllers.aboutYourLeaseOrTenure.routes.RentIncludeFixtureAndFittingsController.show().url
+            answers.forType match {
+              case ForTypes.for6020 =>
+                controllers.aboutYourLeaseOrTenure.routes.IncludedInRent6020Controller.show().url
+              case _                =>
+                controllers.aboutYourLeaseOrTenure.routes.RentIncludeFixtureAndFittingsController.show().url
+            }
         }
     }
 

--- a/app/form/ConditionalConstraintMapping.scala
+++ b/app/form/ConditionalConstraintMapping.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package form
+
+import play.api.data.validation.Constraint
+import play.api.data.{FormError, Mapping}
+import uk.gov.voa.play.form.Condition
+
+/**
+  * @author Yuriy Tumakha
+  */
+case class ConditionalConstraintMapping[T](
+  condition: Condition,
+  conditionalMapping: Mapping[T],
+  defaultMapping: Mapping[T],
+  constraints: Seq[Constraint[T]] = Seq.empty
+) extends Mapping[T] {
+
+  override val format: Option[(String, Seq[Any])] = defaultMapping.format
+
+  val key: String = defaultMapping.key
+
+  def verifying(addConstraints: Constraint[T]*): Mapping[T] =
+    this.copy(constraints = constraints ++ addConstraints.toSeq)
+
+  def bind(data: Map[String, String]): Either[Seq[FormError], T] =
+    if (condition(data)) {
+      conditionalMapping.bind(data)
+    } else {
+      defaultMapping.bind(data)
+    }
+
+  def unbind(value: T): Map[String, String] = defaultMapping.unbind(value)
+
+  def unbindAndValidate(value: T): (Map[String, String], Seq[FormError]) = defaultMapping.unbindAndValidate(value)
+
+  def withPrefix(prefix: String): Mapping[T] =
+    copy(conditionalMapping = conditionalMapping.withPrefix(prefix), defaultMapping = defaultMapping.withPrefix(prefix))
+
+  val mappings: Seq[Mapping[_]] = (conditionalMapping.mappings ++ defaultMapping.mappings) :+ this
+
+}

--- a/app/form/ConditionalConstraintMappings.scala
+++ b/app/form/ConditionalConstraintMappings.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package form
+
+import play.api.data.Forms.{default, text}
+import play.api.data.Mapping
+import play.api.data.validation.Constraint
+import play.api.data.validation.Constraints.nonEmpty
+import uk.gov.voa.play.form.Condition
+
+/**
+  * @author Yuriy Tumakha
+  */
+object ConditionalConstraintMappings {
+
+  def applyConstraintsOnCondition[T](
+    condition: Condition,
+    mapping: Mapping[T],
+    conditionalConstraints: Constraint[T]*
+  ): Mapping[T] =
+    ConditionalConstraintMapping(condition, mapping.verifying(conditionalConstraints: _*), mapping)
+
+  def mandatoryStringIfExists(fieldName: String, errorRequired: String): Mapping[String] =
+    applyConstraintsOnCondition[String](
+      _.contains(fieldName),
+      default(text, ""),
+      nonEmpty(errorMessage = errorRequired)
+    )
+
+}

--- a/app/form/aboutYourLeaseOrTenure/IncludedInRent6020Form.scala
+++ b/app/form/aboutYourLeaseOrTenure/IncludedInRent6020Form.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package form.aboutYourLeaseOrTenure
+
+import models.submissions.aboutYourLeaseOrTenure.DoesTheRentPayable
+import play.api.data.Form
+import play.api.data.Forms.{default, list, mapping, text}
+import play.api.data.validation.Constraints.{maxLength, nonEmpty}
+import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfExists
+
+object IncludedInRent6020Form {
+
+  val includedInRent6020Form: Form[DoesTheRentPayable] = Form(
+    mapping(
+      "rentPayable"        -> list(text),
+      "rentPayableDetails" -> mandatoryIfExists(
+        "rentPayable[0]",
+        default(text, "").verifying(
+          nonEmpty(errorMessage = "error.rentPayableDetails.required")
+        )
+      ).transform[String](_.getOrElse(""), Some(_))
+        .verifying(
+          maxLength(2000, "error.rentPayableDetails.maxLength")
+        )
+    )(DoesTheRentPayable.apply)(DoesTheRentPayable.unapply)
+  )
+
+}

--- a/app/form/aboutYourLeaseOrTenure/IncludedInRent6020Form.scala
+++ b/app/form/aboutYourLeaseOrTenure/IncludedInRent6020Form.scala
@@ -16,26 +16,23 @@
 
 package form.aboutYourLeaseOrTenure
 
+import form.ConditionalConstraintMappings.mandatoryStringIfExists
 import models.submissions.aboutYourLeaseOrTenure.DoesTheRentPayable
 import play.api.data.Form
-import play.api.data.Forms.{default, list, mapping, text}
-import play.api.data.validation.Constraints.{maxLength, nonEmpty}
-import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfExists
+import play.api.data.Forms.{list, mapping, text}
+import play.api.data.validation.Constraints.maxLength
 
 object IncludedInRent6020Form {
 
   val includedInRent6020Form: Form[DoesTheRentPayable] = Form(
     mapping(
       "rentPayable"        -> list(text),
-      "rentPayableDetails" -> mandatoryIfExists(
+      "rentPayableDetails" -> mandatoryStringIfExists(
         "rentPayable[0]",
-        default(text, "").verifying(
-          nonEmpty(errorMessage = "error.rentPayableDetails.required")
-        )
-      ).transform[String](_.getOrElse(""), Some(_))
-        .verifying(
-          maxLength(2000, "error.rentPayableDetails.maxLength")
-        )
+        "error.rentPayableDetails.required"
+      ).verifying(
+        maxLength(2000, "error.rentPayableDetails.maxLength")
+      )
     )(DoesTheRentPayable.apply)(DoesTheRentPayable.unapply)
   )
 

--- a/app/models/submissions/aboutYourLeaseOrTenure/DoesTheRentPayable.scala
+++ b/app/models/submissions/aboutYourLeaseOrTenure/DoesTheRentPayable.scala
@@ -18,11 +18,18 @@ package models.submissions.aboutYourLeaseOrTenure
 
 import play.api.libs.json.{Json, OFormat}
 
+/**
+  * Used to store data from pages:
+  * <pre>
+  * /does-the-rent-payable
+  * /included-in-rent
+  * </pre>
+  */
 case class DoesTheRentPayable(
   rentPayable: List[String] = List.empty,
   detailsToQuestions: String
 )
 
 object DoesTheRentPayable {
-  implicit val format: OFormat[DoesTheRentPayable] = Json.format[DoesTheRentPayable]
+  implicit val format: OFormat[DoesTheRentPayable] = Json.format
 }

--- a/app/navigation/AboutYourLeaseOrTenureNavigator.scala
+++ b/app/navigation/AboutYourLeaseOrTenureNavigator.scala
@@ -180,9 +180,7 @@ class AboutYourLeaseOrTenureNavigator @Inject() (audit: Audit) extends Navigator
       }
     } else {
       answers.forType match {
-        case ForTypes.for6020 =>
-          controllers.aboutYourLeaseOrTenure.routes.RentOpenMarketValueController
-            .show() // TODO: Does rent include the following
+        case ForTypes.for6020 => controllers.aboutYourLeaseOrTenure.routes.IncludedInRent6020Controller.show()
         case _                => controllers.aboutYourLeaseOrTenure.routes.RentOpenMarketValueController.show()
       }
     }
@@ -503,9 +501,8 @@ class AboutYourLeaseOrTenureNavigator @Inject() (audit: Audit) extends Navigator
     IsParkingRentPaidSeparatelyId                 -> isParkingRentPaidSeparatelyRouting,
     RentedSeparatelyParkingSpacesId               -> (_ => aboutYourLeaseOrTenure.routes.CarParkingAnnualRentController.show()),
     CarParkingAnnualRentId                        -> (_ => aboutYourLeaseOrTenure.routes.RentIncludeFixtureAndFittingsController.show()),
-    RentedEquipmentDetailsId                      -> (_ =>
-      aboutYourLeaseOrTenure.routes.RentOpenMarketValueController.show()
-    ), // TODO: Does rent include the following
+    RentedEquipmentDetailsId                      -> (_ => aboutYourLeaseOrTenure.routes.IncludedInRent6020Controller.show()),
+    IncludedInRent6020Id                          -> (_ => aboutYourLeaseOrTenure.routes.RentOpenMarketValueController.show()),
     CheckYourAnswersAboutYourLeaseOrTenureId      -> (_ => controllers.routes.TaskListController.show())
   )
 }

--- a/app/navigation/identifiers/AboutYourLeaseOrTenureIdenifiers.scala
+++ b/app/navigation/identifiers/AboutYourLeaseOrTenureIdenifiers.scala
@@ -220,3 +220,7 @@ case object CarParkingAnnualRentId extends Identifier {
 case object RentedEquipmentDetailsId extends Identifier {
   override def toString: String = "rentedEquipmentDetailsPage"
 }
+
+case object IncludedInRent6020Id extends Identifier {
+  override def toString: String = "includedInRent6020Page"
+}

--- a/app/views/aboutYourLeaseOrTenure/includedInRent6020.scala.html
+++ b/app/views/aboutYourLeaseOrTenure/includedInRent6020.scala.html
@@ -1,0 +1,106 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import actions.SessionRequest
+@import models.submissions.aboutYourLeaseOrTenure.DoesTheRentPayable
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcCharacterCount
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.CharacterCount
+@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichCharacterCount
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        govukCheckboxes: GovukCheckboxes,
+        hmrcCharacterCount: HmrcCharacterCount,
+        formWithCSRF: FormWithCSRF
+)
+
+
+@(form: Form[DoesTheRentPayable], backLinkUrl: String)(implicit request: SessionRequest[_], messages: Messages)
+
+@layout(
+    pageHeading = messages("includedInRent6020.heading"),
+    showH1 = false,
+    showSection = true,
+    summary = Some(request.sessionData.toSummary),
+    sectionName = messages("label.section.aboutYourLeaseOrTenure"),
+    backLinkUrl = backLinkUrl,
+    theForm = form
+) {
+
+    @formWithCSRF(action = controllers.aboutYourLeaseOrTenure.routes.IncludedInRent6020Controller.submit()) {
+
+        @govukCheckboxes(
+            Checkboxes(
+                name = "rentPayable[]",
+                fieldset = Fieldset(
+                    legend = Legend(
+                        content = Text(Messages("includedInRent6020.heading")),
+                        classes = "govuk-fieldset__legend--l",
+                        isPageHeading = true
+                    )
+                ),
+                hint = Hint(content = Text(messages("rentPayable.hint"))),
+                items = Seq(
+                    CheckboxItem(
+                        id = "fullyEquippedStation",
+                        content = Text(messages("checkbox.rentPayable.fullyEquippedStation")),
+                        value = "fullyEquippedStation"
+                    ),
+                    CheckboxItem(
+                        id = "landOnly",
+                        content = Text(messages("checkbox.rentPayable.landOnly")),
+                        value = "landOnly"
+                    ),
+                    CheckboxItem(
+                        id = "otherProperty",
+                        content = Text(messages("checkbox.rentPayable.otherProperty")),
+                        value = "otherProperty"
+                    ),
+                    CheckboxItem(
+                        id = "onlyPart",
+                        content = Text(messages("checkbox.rentPayable.onlyPart")),
+                        value = "onlyPart"
+                    ),
+                    CheckboxItem(
+                        id = "shellUnit",
+                        content = Text(messages("checkbox.rentPayable.shellUnit")),
+                        value = "shellUnit"
+                    )
+                )
+            ).withFormField(form("rentPayable"))
+        )
+
+        @hmrcCharacterCount(
+            CharacterCount(
+                rows = 3,
+                maxLength = 2000,
+                label = Label(
+                    content = Text(messages("rentPayableDetails.label")),
+                    classes = "govuk-label--m"
+                ),
+                hint = Hint(
+                    content = Text(messages("rentPayableDetails.hint"))
+                )
+            ).withFormField(form("rentPayableDetails"))
+        )
+
+        @includes.continueSaveAsDraftButtons(govukButton)
+    }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -295,8 +295,8 @@ POST        /current-lease-or-agreement-begin                       controllers.
 GET         /included-in-your-rent                                  controllers.aboutYourLeaseOrTenure.IncludedInYourRentController.show()
 POST        /included-in-your-rent                                  controllers.aboutYourLeaseOrTenure.IncludedInYourRentController.submit()
 
-GET         /rent-includes-vat                                        controllers.aboutYourLeaseOrTenure.RentIncludesVatController.show()
-POST        /rent-includes-vat                                        controllers.aboutYourLeaseOrTenure.RentIncludesVatController.submit()
+GET         /rent-includes-vat                                      controllers.aboutYourLeaseOrTenure.RentIncludesVatController.show()
+POST        /rent-includes-vat                                      controllers.aboutYourLeaseOrTenure.RentIncludesVatController.submit()
 
 GET         /does-the-rent-payable                                  controllers.aboutYourLeaseOrTenure.DoesTheRentPayableController.show()
 POST        /does-the-rent-payable                                  controllers.aboutYourLeaseOrTenure.DoesTheRentPayableController.submit()
@@ -407,6 +407,9 @@ POST        /car-parking-annual-rent                                controllers.
 
 GET         /rented-equipment-details                               controllers.aboutYourLeaseOrTenure.RentedEquipmentDetailsController.show()
 POST        /rented-equipment-details                               controllers.aboutYourLeaseOrTenure.RentedEquipmentDetailsController.submit()
+
+GET         /included-in-rent                                       controllers.aboutYourLeaseOrTenure.IncludedInRent6020Controller.show()
+POST        /included-in-rent                                       controllers.aboutYourLeaseOrTenure.IncludedInRent6020Controller.submit()
 
 #Form 6030 routing
 GET         /concession-or-franchise-fee                            controllers.aboutfranchisesorlettings.ConcessionOrFranchiseFeeController.show()

--- a/conf/messages
+++ b/conf/messages
@@ -856,7 +856,7 @@ hint.detailsToQuestions = Give details if you want to tell us more about any opt
 error.doesTheRentPayable.required = Select any options included in the rent, or select ’No, the rent does not include any of these options’
 error.doesTheRentPayable.noneSelectedWithOther = Select any options included in the rent, or select ’No, the rent does not include any of these options’
 error.detailsToQuestions.required = Please provide further information
-error.detailsToQuestions.maxLength = Additional information must be 500 characters or fewer
+error.detailsToQuestions.maxLength = Additional information must be {0} characters or fewer
 
 # RENT PAYABLE VARY ON QUANTITY OF BEERS
 #######################################
@@ -1905,6 +1905,16 @@ error.rentedSeparately.garages.required = Enter 0 if you do not rent separately 
 error.rentedSeparately.garages.nonNumeric = The amount of garages rented separately must be a number
 error.rentedSeparately.garages.negative = The number of garages rented separately cannot be a negative number
 fieldName.carParkingFixedRentDate = the date when the annual payment was fixed
+
+# INCLUDED IN RENT 6020
+includedInRent6020.heading = Does the rent payable include or relate to any of the following?
+rentPayable.hint = Select any that apply.
+checkbox.rentPayable.fullyEquippedStation = Fully equipped operational filling station
+checkbox.rentPayable.landOnly = Land only (not including buildings)
+rentPayableDetails.label = Give details if you selected any of the options
+rentPayableDetails.hint = For example, includes the premises next door.
+error.rentPayableDetails.required = Please give details of selected items included in rent payable
+error.rentPayableDetails.maxLength = Description of selected items included in rent payable must be {0} characters or fewer
 
 # CHECK YOUR ANSWERS
 ####################

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -868,7 +868,7 @@ hint.detailsToQuestions = Give details if you want to tell us more about any opt
 error.doesTheRentPayable.required = Dewiswch yr eitemau sydd wedi’u cynnwys yn eich rhent, neu dewiswch ‘Na, nid oes yr un o’r rhain wedi’u cynnwys yn y rhent’
 error.doesTheRentPayable.noneSelectedWithOther = Dewiswch yr eitemau sydd wedi’u cynnwys yn eich rhent, neu dewiswch ‘Na, nid oes yr un o’r rhain wedi’u cynnwys yn y rhent’
 error.detailsToQuestions.required = Please provide further information
-error.detailsToQuestions.maxLength = Mae’n rhaid i’r wybodaeth ychwanegol fod yn 500 o gymeriadau neu lai
+error.detailsToQuestions.maxLength = Mae’n rhaid i’r wybodaeth ychwanegol fod yn {0} o gymeriadau neu lai
 
 # RENT PAYABLE VARY ON QUANTITY OF BEERS
 #######################################
@@ -1879,6 +1879,16 @@ error.rentedSeparately.garages.required = Enter 0 if you do not rent separately 
 error.rentedSeparately.garages.nonNumeric = The amount of garages rented separately must be a number
 error.rentedSeparately.garages.negative = The number of garages rented separately cannot be a negative number
 fieldName.carParkingFixedRentDate = the date when the annual payment was fixed
+
+# INCLUDED IN RENT 6020
+includedInRent6020.heading = Does the rent payable include or relate to any of the following?
+rentPayable.hint = Select any that apply.
+checkbox.rentPayable.fullyEquippedStation = Fully equipped operational filling station
+checkbox.rentPayable.landOnly = Land only (not including buildings)
+rentPayableDetails.label = Give details if you selected any of the options
+rentPayableDetails.hint = For example, includes the premises next door.
+error.rentPayableDetails.required = Please give details of selected items included in rent payable
+error.rentPayableDetails.maxLength = Description of selected items included in rent payable must be {0} characters or fewer
 
 # CHECK YOUR ANSWERS
 ####################

--- a/test/controllers/aboutYourLeaseOrTenure/IncludedInRent6020ControllerSpec.scala
+++ b/test/controllers/aboutYourLeaseOrTenure/IncludedInRent6020ControllerSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.aboutYourLeaseOrTenure
+
+import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{charset, contentType, redirectLocation, status, stubMessagesControllerComponents}
+import utils.TestBaseSpec
+
+/**
+  * @author Yuriy Tumakha
+  */
+class IncludedInRent6020ControllerSpec extends TestBaseSpec {
+
+  def includedInRent6020Controller =
+    new IncludedInRent6020Controller(
+      includedInRent6020View,
+      aboutYourLeaseOrTenureNavigator,
+      preEnrichedActionRefiner(aboutLeaseOrAgreementPartOne = Some(prefilledAboutLeaseOrAgreementPartOne)),
+      mockSessionRepo,
+      stubMessagesControllerComponents()
+    )
+
+  "GET /" should {
+    "return 200 and HTML with Rented Equipment Details in the session" in {
+      val result = includedInRent6020Controller.show(fakeRequest)
+      status(result)      shouldBe OK
+      contentType(result) shouldBe Some("text/html")
+      charset(result)     shouldBe Some("utf-8")
+    }
+  }
+
+  "SUBMIT /" should {
+    "redirect to the next page if an empty form is submitted" in {
+      val res = includedInRent6020Controller.submit(
+        FakeRequest("POST", "/").withFormUrlEncodedBody()
+      )
+      status(res)           shouldBe SEE_OTHER
+      redirectLocation(res) shouldBe Some(
+        controllers.aboutYourLeaseOrTenure.routes.RentOpenMarketValueController.show().url
+      )
+    }
+
+    "return BAD_REQUEST if any rentPayable items selected but description is empty" in {
+      val res = includedInRent6020Controller.submit(
+        FakeRequest("POST", "/").withFormUrlEncodedBody("rentPayable[0]" -> "landOnly")
+      )
+      status(res) shouldBe BAD_REQUEST
+      redirectLocation(res) shouldBe None
+    }
+  }
+
+}

--- a/test/controllers/aboutYourLeaseOrTenure/RentedEquipmentDetailsControllerSpec.scala
+++ b/test/controllers/aboutYourLeaseOrTenure/RentedEquipmentDetailsControllerSpec.scala
@@ -16,9 +16,9 @@
 
 package controllers.aboutYourLeaseOrTenure
 
-import play.api.http.Status.{BAD_REQUEST, OK}
+import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{charset, contentType, status, stubMessagesControllerComponents}
+import play.api.test.Helpers.{charset, contentType, redirectLocation, status, stubMessagesControllerComponents}
 import utils.TestBaseSpec
 
 /**
@@ -67,6 +67,17 @@ class RentedEquipmentDetailsControllerSpec extends TestBaseSpec {
       )
       status(res) shouldBe BAD_REQUEST
     }
+
+    "redirect to the next page if field `rentedEquipmentDetails` is filled" in {
+      val res = rentedEquipmentDetailsController.submit(
+        FakeRequest("POST", "/").withFormUrlEncodedBody("rentedEquipmentDetails" -> "Equipment details")
+      )
+      status(res) shouldBe SEE_OTHER
+      redirectLocation(res) shouldBe Some(
+        controllers.aboutYourLeaseOrTenure.routes.IncludedInRent6020Controller.show().url
+      )
+    }
+
   }
 
 }

--- a/test/form/ConditionalConstraintMappingsSpec.scala
+++ b/test/form/ConditionalConstraintMappingsSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package form
+
+import form.ConditionalConstraintMappings.mandatoryStringIfExists
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import play.api.data.{Form, FormError}
+import play.api.data.Forms.{list, mapping, text}
+import play.api.data.validation.Constraints.maxLength
+
+/**
+  * @author Yuriy Tumakha
+  */
+class ConditionalConstraintMappingsSpec extends AnyFlatSpec with should.Matchers {
+
+  private val form: Form[Model] = Form(
+    mapping(
+      "items"       -> list(text),
+      "description" -> mandatoryStringIfExists(
+        "items[0]",
+        "error.itemsDescription.required"
+      ).verifying(
+        maxLength(2000, "error.itemsDescription.maxLength")
+      )
+    )(Model.apply)(Model.unapply)
+  )
+
+  "mandatoryStringIfExists" should "bind all mapped values" in {
+    val data = Map("items[0]" -> "landOnly", "description" -> "Selected items details", "unknown" -> "value")
+    val res  = form.bind(data)
+
+    res.errors shouldBe empty
+    res.value  shouldBe Some(Model(List("landOnly"), "Selected items details"))
+  }
+
+  it should "make mandatory `description` field if any value selected for `items` field" in {
+    val data = Map("items[0]" -> "property")
+    val res  = form.bind(data)
+
+    res.errors shouldBe List(FormError("description", List("error.itemsDescription.required"), List.empty))
+    res.value  shouldBe None
+  }
+
+  it should "make optional `description` field if no value for `items` field is supplied" in {
+    val res = form.bind(Map.empty[String, String])
+
+    res.errors shouldBe empty
+    res.value  shouldBe Some(Model(List.empty, ""))
+  }
+
+  it should "bind value for optional `description` field if no value for `items` field is supplied" in {
+    val data = Map("description" -> "Selected items details")
+    val res  = form.bind(data)
+
+    res.errors shouldBe empty
+    res.value  shouldBe Some(Model(List.empty, "Selected items details"))
+  }
+
+  case class Model(
+    items: List[String] = List.empty,
+    description: String
+  )
+
+}

--- a/test/utils/FakeViews.scala
+++ b/test/utils/FakeViews.scala
@@ -316,6 +316,7 @@ trait FakeViews { this: GuiceOneAppPerSuite =>
   lazy val throughputAffectsRentDetailsView = app.injector.instanceOf[throughputAffectsRentDetails]
   lazy val isVATPayableForWholePropertyView = app.injector.instanceOf[isVATPayableForWholeProperty]
   lazy val rentedEquipmentDetailsView       = app.injector.instanceOf[rentedEquipmentDetails]
+  lazy val includedInRent6020View           = app.injector.instanceOf[includedInRent6020]
 
   // Max letting reached
   lazy val maxOfLettingsReachedView =


### PR DESCRIPTION
- Created form *IncludedInRent6020Form* and validation error messages for new page */included-in-rent*
- Reused session model property *AboutLeaseOrAgreementPartOne.doesTheRentPayable* to store page data(list and textarea) in frontend and backend.
- Created *ConditionalConstraintMapping* for adding required error to one field when another field is not empty list by new mapping *mandatoryStringIfExists*
- Created page template for */included-in-rent*
- Implemented *IncludedInRent6020Controller*
- Forward & backward navigation for */included-in-rent* and linked pages */rented-equipment-details*, */rent-open-market-value*
- Added unit tests to achieve coverage beyond *82.7%*