### PR TITLE
BST-97581 Added model `CaravansTrading6045` and reused for 4 pages

### DIFF
--- a/app/models/submissions/aboutthetradinghistory/CaravansTrading6045.scala
+++ b/app/models/submissions/aboutthetradinghistory/CaravansTrading6045.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.submissions.aboutthetradinghistory
+
+import play.api.libs.json.{Json, OFormat}
+
+/**
+  * 6045/6046 Caravans trading history for one financial year.
+  *
+  * @author Yuriy Tumakha
+  */
+case class CaravansTrading6045(
+  tradingPeriod: Int = 52,
+  grossReceipts: Option[BigDecimal] = None,
+  vans: Option[Int] = None
+)
+
+object CaravansTrading6045 {
+  implicit val format: OFormat[CaravansTrading6045] = Json.format
+}

--- a/app/models/submissions/aboutthetradinghistory/TurnoverSection6045.scala
+++ b/app/models/submissions/aboutthetradinghistory/TurnoverSection6045.scala
@@ -29,6 +29,10 @@ case class TurnoverSection6045(
   financialYearEnd: LocalDate,
   // 3. Caravans
   grossReceiptsCaravanFleetHire: Option[GrossReceiptsCaravanFleetHire] = None,
+  singleCaravansOwnedByOperator: Option[CaravansTrading6045] = None,
+  singleCaravansSublet: Option[CaravansTrading6045] = None, // sub-let by operator on behalf of private owners
+  twinUnitCaravansOwnedByOperator: Option[CaravansTrading6045] = None,
+  twinUnitCaravansSublet: Option[CaravansTrading6045] = None, // sub-let by operator on behalf of private owners
   // 3.1.0 Other holiday accommodation
   grossReceiptsLettingUnits: Option[GrossReceiptsLettingUnits] = None,
   // 3.2.0 Touring and tenting pitches

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -33,6 +33,7 @@ object AppDependencies {
     "org.scalatestplus"      %% "scalacheck-1-18"         % scalaTestPlusScalaCheckVersion % Test,
     "org.scalatestplus"      %% "mockito-5-12"            % scalaTestPlusMockitoVersion    % Test,
     "com.vladsch.flexmark"    % "flexmark-all"            % flexMarkVersion                % Test, // for scalatest 3.2.x
+    // TODO: Upgrade wiremock when jackson-databind become compatible with Play and bootstrap-test-play-30
     // "org.wiremock"            % "wiremock"                % wiremockVersion                % Test,
     "org.jsoup"               % "jsoup"                   % jsoupVersion                   % Test
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.1

--- a/test/utils/FakeObjects.scala
+++ b/test/utils/FakeObjects.scala
@@ -16,17 +16,17 @@
 
 package utils
 
-import models.submissions.Form6010._
-import models.submissions.aboutYourLeaseOrTenure._
-import models.submissions.aboutfranchisesorlettings._
-import models.submissions.aboutthetradinghistory._
-import models.submissions.aboutyouandtheproperty._
-import models.submissions.additionalinformation._
-import models.submissions.common._
-import models.submissions.connectiontoproperty._
+import models.submissions.Form6010.*
+import models.submissions.aboutYourLeaseOrTenure.*
+import models.submissions.aboutfranchisesorlettings.*
+import models.submissions.aboutthetradinghistory.*
+import models.submissions.aboutyouandtheproperty.*
+import models.submissions.additionalinformation.*
+import models.submissions.common.*
+import models.submissions.connectiontoproperty.*
 import models.submissions.downloadFORTypeForm.{DownloadPDF, DownloadPDFDetails, DownloadPDFReferenceNumber}
 import models.submissions.notconnected.{PastConnectionTypeYes, RemoveConnectionDetails, RemoveConnectionsDetails}
-import models.submissions.requestReferenceNumber._
+import models.submissions.requestReferenceNumber.*
 import models.submissions.{ConnectedSubmission, NotConnectedSubmission, aboutfranchisesorlettings}
 import models.{AnnualRent, ForTypes, Session, SubmissionDraft}
 
@@ -575,7 +575,11 @@ trait FakeObjects {
     turnoverSections6045 = Seq(
       TurnoverSection6045(
         today,
-        grossReceiptsCaravanFleetHire = GrossReceiptsCaravanFleetHire()
+        grossReceiptsCaravanFleetHire = GrossReceiptsCaravanFleetHire(),
+        singleCaravansOwnedByOperator = CaravansTrading6045(52, 3000, 30),
+        singleCaravansSublet = CaravansTrading6045(52, 1000, 10),
+        twinUnitCaravansOwnedByOperator = CaravansTrading6045(26, 2000, 20),
+        twinUnitCaravansSublet = CaravansTrading6045()
       ),
       TurnoverSection6045(
         today.minusYears(1),


### PR DESCRIPTION
Added model `CaravansTrading6045` and reused it for 4 pages - single/twinUnit caravans OwnedByOperator/SubletByOperator
