### PR TITLE
BST-109988 6048 - Added page "Occupation and accounting CYA". Used new model `TurnoverSection6048` in accounting info controllers

### DIFF
--- a/app/controllers/aboutthetradinghistory/AboutYourTradingHistoryController.scala
+++ b/app/controllers/aboutthetradinghistory/AboutYourTradingHistoryController.scala
@@ -84,7 +84,8 @@ class AboutYourTradingHistoryController @Inject() (
                   && (
                     newFinancialYears(occupationAndAccounting) == previousFinancialYears ||
                       newFinancialYears(occupationAndAccounting) == previousFinancialYears6076 ||
-                      newFinancialYears(occupationAndAccounting) == previousFinancialYears6045
+                      newFinancialYears(occupationAndAccounting) == previousFinancialYears6045 ||
+                      newFinancialYears(occupationAndAccounting) == previousFinancialYears6048
                   )
               )
               .getOrElse(navigator.nextPage(AboutYourTradingHistoryPageId, updatedData).apply(updatedData))

--- a/app/controllers/aboutthetradinghistory/EditFinancialYearEndDateController.scala
+++ b/app/controllers/aboutthetradinghistory/EditFinancialYearEndDateController.scala
@@ -58,6 +58,10 @@ class EditFinancialYearEndDateController @Inject() (
               request.sessionData.aboutTheTradingHistoryPartOne
                 .flatMap(_.turnoverSections6045)
                 .fold(Seq.empty[LocalDate])(_.map(_.financialYearEnd))
+            case FOR6048           =>
+              request.sessionData.aboutTheTradingHistoryPartOne
+                .flatMap(_.turnoverSections6048)
+                .fold(Seq.empty[LocalDate])(_.map(_.financialYearEnd))
             case FOR6076           =>
               request.sessionData.aboutTheTradingHistoryPartOne
                 .flatMap(_.turnoverSections6076)
@@ -82,6 +86,8 @@ class EditFinancialYearEndDateController @Inject() (
       case FOR6030           => aboutTheTradingHistory.turnoverSections6030.nonEmpty
       case FOR6045 | FOR6046 =>
         request.sessionData.aboutTheTradingHistoryPartOne.flatMap(_.turnoverSections6045).exists(_.nonEmpty)
+      case FOR6048           =>
+        request.sessionData.aboutTheTradingHistoryPartOne.flatMap(_.turnoverSections6048).exists(_.nonEmpty)
       case FOR6076           =>
         request.sessionData.aboutTheTradingHistoryPartOne.flatMap(_.turnoverSections6076).exists(_.nonEmpty)
       case _                 => aboutTheTradingHistory.turnoverSections.nonEmpty
@@ -98,6 +104,10 @@ class EditFinancialYearEndDateController @Inject() (
         case FOR6045 | FOR6046 =>
           request.sessionData.aboutTheTradingHistoryPartOne
             .flatMap(_.turnoverSections6045)
+            .fold(Seq.empty[LocalDate])(_.map(_.financialYearEnd))
+        case FOR6048           =>
+          request.sessionData.aboutTheTradingHistoryPartOne
+            .flatMap(_.turnoverSections6048)
             .fold(Seq.empty[LocalDate])(_.map(_.financialYearEnd))
         case FOR6076           =>
           request.sessionData.aboutTheTradingHistoryPartOne
@@ -136,6 +146,7 @@ class EditFinancialYearEndDateController @Inject() (
               case FOR6030           =>
                 buildUpdateData6030(aboutTheTradingHistory, index, data, newOccupationAndAccounting)
               case FOR6045 | FOR6046 => buildUpdatedData6045(index, data, newOccupationAndAccounting)
+              case FOR6048           => buildUpdatedData6048(index, data, newOccupationAndAccounting)
               case FOR6076           => buildUpdatedData6076(index, data, newOccupationAndAccounting)
               case _                 => buildUpdateData(aboutTheTradingHistory, index, data, newOccupationAndAccounting)
             }
@@ -166,6 +177,11 @@ class EditFinancialYearEndDateController @Inject() (
           .flatMap(_.turnoverSections6045)
           .flatMap(_.headOption)
           .exists(_.grossReceiptsCaravanFleetHire.isDefined)
+      case FOR6048           =>
+        request.sessionData.aboutTheTradingHistoryPartOne
+          .flatMap(_.turnoverSections6048)
+          .flatMap(_.headOption)
+          .exists(_.income.isDefined)
       case FOR6076           =>
         request.sessionData.aboutTheTradingHistoryPartOne
           .flatMap(_.turnoverSections6076)
@@ -263,6 +279,32 @@ class EditFinancialYearEndDateController @Inject() (
         updatedData.aboutTheTradingHistoryPartOne
           .getOrElse(AboutTheTradingHistoryPartOne())
           .copy(turnoverSections6045 = Some(updatedTurnoverSections))
+      )
+    )
+  }
+
+  private def buildUpdatedData6048(
+    index: Int,
+    data: LocalDate,
+    newOccupationAndAccounting: OccupationalAndAccountingInformation
+  )(implicit request: SessionRequest[AnyContent]): Session = {
+    val turnoverSections6048    =
+      request.sessionData.aboutTheTradingHistoryPartOne.flatMap(_.turnoverSections6048).getOrElse(Seq.empty)
+    val updatedTurnoverSections = turnoverSections6048.updated(
+      index,
+      turnoverSections6048(index).copy(financialYearEnd = data)
+    )
+
+    val updatedData = updateAboutTheTradingHistory(
+      _.copy(
+        occupationAndAccountingInformation = Some(newOccupationAndAccounting)
+      )
+    )
+    updatedData.copy(
+      aboutTheTradingHistoryPartOne = Some(
+        updatedData.aboutTheTradingHistoryPartOne
+          .getOrElse(AboutTheTradingHistoryPartOne())
+          .copy(turnoverSections6048 = Some(updatedTurnoverSections))
       )
     )
   }

--- a/app/controllers/aboutthetradinghistory/FinancialYearEndController.scala
+++ b/app/controllers/aboutthetradinghistory/FinancialYearEndController.scala
@@ -107,6 +107,12 @@ class FinancialYearEndController @Inject() (
                   newOccupationAndAccounting,
                   isFinancialYearEndDayUnchanged
                 )
+              case FOR6048           =>
+                buildUpdatedData6048(
+                  aboutTheTradingHistory,
+                  newOccupationAndAccounting,
+                  isFinancialYearEndDayUnchanged
+                )
               case FOR6076           =>
                 buildUpdatedData6076(
                   aboutTheTradingHistory,
@@ -140,6 +146,12 @@ class FinancialYearEndController @Inject() (
                             .flatMap(_.turnoverSections6045)
                             .flatMap(_.headOption)
                             .exists(_.grossReceiptsCaravanFleetHire.isDefined)
+                      ) || (
+                        request.sessionData.forType == FOR6048 &&
+                          request.sessionData.aboutTheTradingHistoryPartOne
+                            .flatMap(_.turnoverSections6048)
+                            .flatMap(_.headOption)
+                            .exists(_.income.isDefined)
                       ))
                   )
                   .getOrElse(navigator.nextPage(FinancialYearEndPageId, updatedData).apply(updatedData))

--- a/app/controllers/aboutthetradinghistory/FinancialYearEndDatesSummaryController.scala
+++ b/app/controllers/aboutthetradinghistory/FinancialYearEndDatesSummaryController.scala
@@ -106,6 +106,11 @@ class FinancialYearEndDatesSummaryController @Inject() (
           .flatMap(_.turnoverSections6045)
           .flatMap(_.headOption)
           .exists(_.grossReceiptsCaravanFleetHire.isDefined)
+      case FOR6048           =>
+        request.sessionData.aboutTheTradingHistoryPartOne
+          .flatMap(_.turnoverSections6048)
+          .flatMap(_.headOption)
+          .exists(_.income.isDefined)
       case FOR6076           =>
         request.sessionData.aboutTheTradingHistoryPartOne
           .flatMap(_.turnoverSections6076)

--- a/app/models/Session.scala
+++ b/app/models/Session.scala
@@ -81,6 +81,11 @@ case class Session(
       .flatMap(_.turnoverSections6045)
       .fold(Seq.empty[(LocalDate, Int)])(_.map(_.financialYearEnd).zipWithIndex)
 
+  def financialYearEndDates6048: Seq[(LocalDate, Int)] =
+    aboutTheTradingHistoryPartOne
+      .flatMap(_.turnoverSections6048)
+      .fold(Seq.empty[(LocalDate, Int)])(_.map(_.financialYearEnd).zipWithIndex)
+
   def financialYearEndDates6076: Seq[(LocalDate, Int)] =
     aboutTheTradingHistoryPartOne
       .flatMap(_.turnoverSections6076)

--- a/app/models/submissions/aboutthetradinghistory/AboutTheTradingHistoryPartOne.scala
+++ b/app/models/submissions/aboutthetradinghistory/AboutTheTradingHistoryPartOne.scala
@@ -41,6 +41,7 @@ case class AboutTheTradingHistoryPartOne(
   additionalMiscDetails: Option[AdditionalMiscDetails] = None,
   fromCYA: Option[Boolean] = None,
   // 6048
+  turnoverSections6048: Option[Seq[TurnoverSection6048]] = None,
   areYouVATRegistered: Option[AnswersYesNo] = None
 )
 

--- a/app/models/submissions/aboutthetradinghistory/TurnoverSection6048.scala
+++ b/app/models/submissions/aboutthetradinghistory/TurnoverSection6048.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.submissions.aboutthetradinghistory
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
+
+/**
+  * 6048 Trading history.
+  *
+  * @author Yuriy Tumakha
+  */
+case class TurnoverSection6048(
+  financialYearEnd: LocalDate,
+  income: Option[BigDecimal] = None // TODO: replace with income: Option[Income6048] = None
+)
+
+object TurnoverSection6048 {
+  implicit val format: OFormat[TurnoverSection6048] = Json.format
+}

--- a/app/navigation/AboutTheTradingHistoryNavigator.scala
+++ b/app/navigation/AboutTheTradingHistoryNavigator.scala
@@ -88,18 +88,18 @@ class AboutTheTradingHistoryNavigator @Inject() (audit: Audit) extends Navigator
     s.aboutTheTradingHistory.flatMap(_.occupationAndAccountingInformation.flatMap(_.yearEndChanged)) match {
       case Some(true) =>
         s.forType match {
-          case FOR6020 | FOR6045 | FOR6046 | FOR6076 =>
+          case FOR6020 | FOR6045 | FOR6046 | FOR6048 | FOR6076 =>
             aboutthetradinghistory.routes.FinancialYearEndDatesSummaryController.show()
-          case _                                     => aboutthetradinghistory.routes.FinancialYearEndDatesController.show()
+          case _                                               => aboutthetradinghistory.routes.FinancialYearEndDatesController.show()
         }
 
       case _ =>
         s.forType match {
-          case FOR6020           => aboutthetradinghistory.routes.TotalFuelSoldController.show()
-          case FOR6030           => aboutthetradinghistory.routes.Turnover6030Controller.show()
-          case FOR6045 | FOR6046 => aboutthetradinghistory.routes.FinancialYearsController.show
-          case FOR6076           => aboutthetradinghistory.routes.ElectricityGeneratedController.show()
-          case _                 => aboutthetradinghistory.routes.TurnoverController.show()
+          case FOR6020                     => aboutthetradinghistory.routes.TotalFuelSoldController.show()
+          case FOR6030                     => aboutthetradinghistory.routes.Turnover6030Controller.show()
+          case FOR6045 | FOR6046 | FOR6048 => aboutthetradinghistory.routes.FinancialYearsController.show
+          case FOR6076                     => aboutthetradinghistory.routes.ElectricityGeneratedController.show()
+          case _                           => aboutthetradinghistory.routes.TurnoverController.show()
         }
     }
   }
@@ -117,11 +117,11 @@ class AboutTheTradingHistoryNavigator @Inject() (audit: Audit) extends Navigator
 
   private def financialYearEndDatesRouting: Session => Call =
     _.forType match {
-      case FOR6020           => aboutthetradinghistory.routes.TotalFuelSoldController.show()
-      case FOR6030           => aboutthetradinghistory.routes.Turnover6030Controller.show()
-      case FOR6045 | FOR6046 => aboutthetradinghistory.routes.FinancialYearsController.show
-      case FOR6076           => aboutthetradinghistory.routes.ElectricityGeneratedController.show()
-      case _                 => aboutthetradinghistory.routes.TurnoverController.show()
+      case FOR6020                     => aboutthetradinghistory.routes.TotalFuelSoldController.show()
+      case FOR6030                     => aboutthetradinghistory.routes.Turnover6030Controller.show()
+      case FOR6045 | FOR6046 | FOR6048 => aboutthetradinghistory.routes.FinancialYearsController.show
+      case FOR6076                     => aboutthetradinghistory.routes.ElectricityGeneratedController.show()
+      case _                           => aboutthetradinghistory.routes.TurnoverController.show()
     }
 
   private def financialYearsRouting: Session => Call =
@@ -129,6 +129,7 @@ class AboutTheTradingHistoryNavigator @Inject() (audit: Audit) extends Navigator
       case FOR6020           => aboutthetradinghistory.routes.TotalFuelSoldController.show()
       case FOR6030           => aboutthetradinghistory.routes.Turnover6030Controller.show()
       case FOR6045 | FOR6046 => aboutthetradinghistory.routes.StaticCaravansController.show()
+      case FOR6048           => aboutthetradinghistory.routes.StaticCaravansController.show() // TODO: Income6048Controller
       case FOR6076           => aboutthetradinghistory.routes.ElectricityGeneratedController.show()
       case _                 => aboutthetradinghistory.routes.TurnoverController.show()
     }

--- a/app/views/aboutthetradinghistory/financialYearEndDatesSummary.scala.html
+++ b/app/views/aboutthetradinghistory/financialYearEndDatesSummary.scala.html
@@ -45,6 +45,7 @@
         case FOR6020 => aboutTheTradingHistory.turnoverSections6020.getOrElse(Seq.empty).map(_.financialYearEnd)
         case FOR6030 => aboutTheTradingHistory.turnoverSections6030.map(_.financialYearEnd)
         case FOR6045 | FOR6046 => request.sessionData.aboutTheTradingHistoryPartOne.flatMap(_.turnoverSections6045).fold(Seq.empty[LocalDate])(_.map(_.financialYearEnd))
+        case FOR6048 => request.sessionData.aboutTheTradingHistoryPartOne.flatMap(_.turnoverSections6048).fold(Seq.empty[LocalDate])(_.map(_.financialYearEnd))
         case FOR6076 => request.sessionData.aboutTheTradingHistoryPartOne.flatMap(_.turnoverSections6076).fold(Seq.empty[LocalDate])(_.map(_.financialYearEnd))
         case _ => aboutTheTradingHistory.turnoverSections.map(_.financialYearEnd)
     }

--- a/app/views/aboutthetradinghistory/financialYears.scala.html
+++ b/app/views/aboutthetradinghistory/financialYears.scala.html
@@ -69,6 +69,7 @@
         case FOR6020 => aboutTheTradingHistory.turnoverSections6020.getOrElse(Seq.empty).map(_.financialYearEnd)
         case FOR6030 => aboutTheTradingHistory.turnoverSections6030.map(_.financialYearEnd)
         case FOR6045 | FOR6046 => request.sessionData.financialYearEndDates6045.map(_._1)
+        case FOR6048 => request.sessionData.financialYearEndDates6048.map(_._1)
         case FOR6076 => request.sessionData.financialYearEndDates6076.map(_._1)
         case _ => aboutTheTradingHistory.turnoverSections.map(_.financialYearEnd)
     }
@@ -144,7 +145,7 @@
                         Seq(
                             ActionItem(
                                 href = forType match {
-                                    case FOR6020 | FOR6045 | FOR6046 | FOR6076 =>
+                                    case FOR6020 | FOR6045 | FOR6046 | FOR6048 | FOR6076 =>
                                         aboutthetradinghistory.routes.FinancialYearEndDatesSummaryController.show().url
                                     case _ => aboutthetradinghistory.routes.FinancialYearEndDatesController.show().url
                                 },

--- a/app/views/answers/answersAboutYourTradingHistory.scala.html
+++ b/app/views/answers/answersAboutYourTradingHistory.scala.html
@@ -28,6 +28,7 @@
 @import models.submissions.aboutthetradinghistory.TurnoverSection6020
 @import models.submissions.aboutthetradinghistory.TurnoverSection6030
 @import models.submissions.aboutthetradinghistory.TurnoverSection6045
+@import models.submissions.aboutthetradinghistory.TurnoverSection6048
 @import models.submissions.aboutthetradinghistory.TurnoverSection6076
 @import models.submissions.aboutthetradinghistory.VariableOperatingExpensesSections
 @import util.DateUtilLocalised
@@ -112,6 +113,7 @@
         case FOR6020 => aboutTheTradingHistory.turnoverSections6020.getOrElse(Seq.empty).map(_.financialYearEnd)
         case FOR6030 => aboutTheTradingHistory.turnoverSections6030.map(_.financialYearEnd)
         case FOR6045 | FOR6046 => request.sessionData.financialYearEndDates6045.map(_._1)
+        case FOR6048 => request.sessionData.financialYearEndDates6048.map(_._1)
         case FOR6076 => request.sessionData.financialYearEndDates6076.map(_._1)
         case _ => aboutTheTradingHistory.turnoverSections.map(_.financialYearEnd)
     }
@@ -487,6 +489,12 @@
         additionalParagraph)
 }
 
+@answer6048(valueLabelKey: String, getAnswer: TurnoverSection6048 => String, additionalParagraph: Option[String] = None) = @{
+    answer(valueLabelKey,
+        sectionAnswers1.answers.flatMap(_.turnoverSections6048).getOrElse(Seq.empty).map(getAnswer),
+        additionalParagraph)
+}
+
 @answer6076(valueLabelKey: String, getAnswer: TurnoverSection6076 => String, additionalParagraph: Option[String] = None) = @{
     answer(valueLabelKey,
         sectionAnswers1.answers.flatMap(_.turnoverSections6076).getOrElse(Seq.empty).map(getAnswer),
@@ -496,7 +504,7 @@
 
 <h2 class="govuk-heading-m">@messages("aboutYourTradingHistory.heading")</h2>
 
-@if(Seq(FOR6045, FOR6046) contains forType) {
+@if(Seq(FOR6045, FOR6046, FOR6048) contains forType) {
     @govukSummaryList(SummaryList(rows =
         sectionAnswers.row("checkYourAnswersAboutTheTradingHistory.occupationDate",
             _.occupationAndAccountingInformation.map(_.firstOccupy.toYearMonth).map(dateUtil.formatYearMonth),
@@ -522,7 +530,7 @@
                 sectionAnswers.row("checkYourAnswersAboutTheTradingHistory.financialYearEndUpdates",
                     _.fold("")(t => financialYearEndDatesTable(financialYearEndDates(t))),
                     forType match {
-                        case FOR6020 | FOR6045 | FOR6046 | FOR6076 =>
+                        case FOR6020 | FOR6045 | FOR6046 | FOR6048 | FOR6076 =>
                             aboutthetradinghistory.routes.FinancialYearEndDatesSummaryController.show()
                         case _ => aboutthetradinghistory.routes.FinancialYearEndDatesController.show()
                     },
@@ -531,7 +539,7 @@
 }
 
 
-@if(!(Seq(FOR6020, FOR6045, FOR6046, FOR6076) contains forType)) {
+@if(!(Seq(FOR6020, FOR6045, FOR6046, FOR6048, FOR6076) contains forType)) {
     <h2 class="govuk-heading-m">@messages("turnover.heading")</h2>
 
     @govukSummaryList(SummaryList(rows =

--- a/test/controllers/aboutthetradinghistory/AboutYourTradingHistoryControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/AboutYourTradingHistoryControllerSpec.scala
@@ -36,7 +36,7 @@ class AboutYourTradingHistoryControllerSpec extends TestBaseSpec {
 
   def aboutYourTradingHistoryController(
     aboutTheTradingHistory: Option[AboutTheTradingHistory] = Some(prefilledAboutYourTradingHistory),
-    forType: ForType = FOR6010,
+    forType: ForType = FOR6010
   ) = new AboutYourTradingHistoryController(
     stubMessagesControllerComponents(),
     aboutYourTradingHistoryNavigator,
@@ -58,7 +58,8 @@ class AboutYourTradingHistoryControllerSpec extends TestBaseSpec {
       val session6048    = aboutYourTradingHistory6048YesSession
       val sessionRequest = SessionRequest(session6048, FakeRequest())
 
-      val result = aboutYourTradingHistoryController(session6048.aboutTheTradingHistory, session6048.forType).show(sessionRequest)
+      val result =
+        aboutYourTradingHistoryController(session6048.aboutTheTradingHistory, session6048.forType).show(sessionRequest)
       status(result) shouldBe Status.OK
     }
 
@@ -91,7 +92,7 @@ class AboutYourTradingHistoryControllerSpec extends TestBaseSpec {
         )
 
       val result = aboutYourTradingHistoryController().submit(sessionRequest)
-      status(result) shouldBe SEE_OTHER
+      status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(aboutthetradinghistory.routes.FinancialYearEndController.show().url)
     }
   }

--- a/test/controllers/aboutthetradinghistory/AboutYourTradingHistoryControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/AboutYourTradingHistoryControllerSpec.scala
@@ -16,13 +16,18 @@
 
 package controllers.aboutthetradinghistory
 
+import actions.SessionRequest
+import controllers.aboutthetradinghistory
 import form.aboutthetradinghistory.OccupationalInformationForm.occupationalInformationForm
+import models.ForType
+import models.ForType.*
 import models.submissions.aboutthetradinghistory.AboutTheTradingHistory
 import play.api.http.Status
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import utils.TestBaseSpec
 import utils.FormBindingTestAssertions.mustContainError
+
 import scala.language.reflectiveCalls
 
 class AboutYourTradingHistoryControllerSpec extends TestBaseSpec {
@@ -30,18 +35,30 @@ class AboutYourTradingHistoryControllerSpec extends TestBaseSpec {
   import TestData.{baseFormData, errorKey}
 
   def aboutYourTradingHistoryController(
-    aboutTheTradingHistory: Option[AboutTheTradingHistory] = Some(prefilledAboutYourTradingHistory)
+    aboutTheTradingHistory: Option[AboutTheTradingHistory] = Some(prefilledAboutYourTradingHistory),
+    forType: ForType = FOR6010,
   ) = new AboutYourTradingHistoryController(
     stubMessagesControllerComponents(),
     aboutYourTradingHistoryNavigator,
     aboutYourTradingHistoryView,
-    preEnrichedActionRefiner(aboutTheTradingHistory = aboutTheTradingHistory),
+    preEnrichedActionRefiner(
+      aboutTheTradingHistory = aboutTheTradingHistory,
+      forType = forType
+    ),
     mockSessionRepo
   )
 
   "About your trading history controller" should {
     "return 200" in {
       val result = aboutYourTradingHistoryController().show(fakeRequest)
+      status(result) shouldBe Status.OK
+    }
+
+    "return 200 for 6048" in {
+      val session6048    = aboutYourTradingHistory6048YesSession
+      val sessionRequest = SessionRequest(session6048, FakeRequest())
+
+      val result = aboutYourTradingHistoryController(session6048.aboutTheTradingHistory, session6048.forType).show(sessionRequest)
       status(result) shouldBe Status.OK
     }
 
@@ -61,6 +78,21 @@ class AboutYourTradingHistoryControllerSpec extends TestBaseSpec {
     "throw a BAD_REQUEST if an empty form is submitted" in {
       val res = aboutYourTradingHistoryController().submit(FakeRequest().withFormUrlEncodedBody(Seq.empty*))
       status(res) shouldBe BAD_REQUEST
+    }
+
+    "redirect to the next page for 6048" in {
+      val requestWithForm = FakeRequest(POST, "/path-to-form-handler")
+        .withFormUrlEncodedBody(baseFormData.toSeq*)
+
+      val sessionRequest =
+        SessionRequest(
+          aboutYourTradingHistory6048YesSession,
+          requestWithForm
+        )
+
+      val result = aboutYourTradingHistoryController().submit(sessionRequest)
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(aboutthetradinghistory.routes.FinancialYearEndController.show().url)
     }
   }
 

--- a/test/controllers/aboutthetradinghistory/CheckYourAnswersAboutTheTradingHistoryControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/CheckYourAnswersAboutTheTradingHistoryControllerSpec.scala
@@ -65,6 +65,14 @@ class CheckYourAnswersAboutTheTradingHistoryControllerSpec extends TestBaseSpec 
     mockSessionRepo
   )
 
+  val checkYourAnswersAboutTradingHistoryController6048 = new CheckYourAnswersAboutTheTradingHistoryController(
+    stubMessagesControllerComponents(),
+    mockAboutTheTradingHistoryNavigator,
+    checkYourAnswersAboutTheTradingHistoryView,
+    preFilledSession6048,
+    mockSessionRepo
+  )
+
   val checkYourAnswersAboutTradingHistoryController6076 = new CheckYourAnswersAboutTheTradingHistoryController(
     stubMessagesControllerComponents(),
     mockAboutTheTradingHistoryNavigator,
@@ -116,6 +124,11 @@ class CheckYourAnswersAboutTheTradingHistoryControllerSpec extends TestBaseSpec 
       val result = checkYourAnswersAboutTradingHistoryController6045.show(fakeRequest)
       contentType(result) shouldBe Some("text/html")
       charset(result)     shouldBe Some("utf-8")
+    }
+
+    "return 200 6048" in {
+      val result = checkYourAnswersAboutTradingHistoryController6048.show(fakeRequest)
+      status(result) shouldBe Status.OK
     }
 
     "return 200 6076" in {

--- a/test/controllers/aboutthetradinghistory/EditFinancialYearEndDateControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/EditFinancialYearEndDateControllerSpec.scala
@@ -262,6 +262,45 @@ class EditFinancialYearEndDateControllerSpec extends TestBaseSpec {
         )
       }
 
+      "redirect to the next page for 6048" in {
+        val index           = 0
+        val requestWithForm = FakeRequest(POST, "/")
+          .withFormUrlEncodedBody(
+            "financialYearEnd.day"   -> "22",
+            "financialYearEnd.month" -> "2",
+            "financialYearEnd.year"  -> "2022"
+          )
+        val session6048     = aboutYourTradingHistory6048YesSession
+        val sessionRequest  = SessionRequest(session6048, requestWithForm)
+
+        val result = editFinancialYearEndDateController(session6048).submit(index)(sessionRequest)
+
+        status(result)           shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(
+          aboutthetradinghistory.routes.FinancialYearEndDatesSummaryController.show().url
+        )
+      }
+
+      "redirect to CYA for 6048" in {
+        val index           = 0
+        val requestWithForm = FakeRequest(POST, "/")
+          .withFormUrlEncodedBody(
+            "financialYearEnd.day"   -> "22",
+            "financialYearEnd.month" -> "2",
+            "financialYearEnd.year"  -> "2022",
+            "from"                   -> "CYA"
+          )
+        val session6048     = aboutYourTradingHistory6048YesSession
+        val sessionRequest  = SessionRequest(session6048, requestWithForm)
+
+        val result = editFinancialYearEndDateController(session6048).submit(index)(sessionRequest)
+
+        status(result)           shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(
+          aboutthetradinghistory.routes.CheckYourAnswersAboutTheTradingHistoryController.show().url
+        )
+      }
+
       "redirect to the next page for 6076" in {
         val index           = 0
         val requestWithForm = FakeRequest(POST, "/")

--- a/test/controllers/aboutthetradinghistory/FinancialYearEndControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/FinancialYearEndControllerSpec.scala
@@ -196,6 +196,28 @@ class FinancialYearEndControllerSpec extends TestBaseSpec {
       )
     }
 
+    "redirect to the next page when valid 6048 data is submitted" in {
+      val validFormData  = Map(
+        "financialYear.day"   -> "25",
+        "financialYear.month" -> "4",
+        "yearEndChanged"      -> "true"
+      )
+      val session6048    = aboutYourTradingHistory6048YesSession
+      val request        = FakeRequest(POST, "/").withFormUrlEncodedBody(validFormData.toSeq*)
+      val sessionRequest = SessionRequest(session6048, request)
+
+      when(mockSessionRepo.saveOrUpdate(any[Session])(any[Writes[Session]], any[HeaderCarrier]))
+        .thenReturn(Future.unit)
+
+      val result =
+        financialYearEndController(session6048.forType, session6048.aboutTheTradingHistory).submit(sessionRequest)
+
+      status(result)           shouldBe SEE_OTHER
+      redirectLocation(result) shouldBe Some(
+        aboutthetradinghistory.routes.FinancialYearEndDatesSummaryController.show().url
+      )
+    }
+
     "redirect to the next page when valid 6076 data is submitted" in {
       val validFormData  = Map(
         "financialYear.day"   -> "6",

--- a/test/controllers/aboutthetradinghistory/FinancialYearEndDatesSummaryControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/FinancialYearEndDatesSummaryControllerSpec.scala
@@ -52,7 +52,7 @@ class FinancialYearEndDatesSummaryControllerSpec extends TestBaseSpec {
 
     "return 200 for 6048" in {
       val session6048    = aboutYourTradingHistory6048YesSession
-      val sessionRequest = SessionRequest(session6048, requestWithForm)
+      val sessionRequest = SessionRequest(session6048, FakeRequest())
 
       val result = financialYearEndDatesSummaryController(session6048.aboutTheTradingHistory, session6048.forType)
         .show()(sessionRequest)

--- a/test/controllers/aboutthetradinghistory/FinancialYearEndDatesSummaryControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/FinancialYearEndDatesSummaryControllerSpec.scala
@@ -50,6 +50,15 @@ class FinancialYearEndDatesSummaryControllerSpec extends TestBaseSpec {
       status(result) shouldBe Status.OK
     }
 
+    "return 200 for 6048" in {
+      val session6048    = aboutYourTradingHistory6048YesSession
+      val sessionRequest = SessionRequest(session6048, requestWithForm)
+
+      val result = financialYearEndDatesSummaryController(session6048.aboutTheTradingHistory, session6048.forType)
+        .show()(sessionRequest)
+      status(result) shouldBe Status.OK
+    }
+
     "return HTML" in {
       val result = financialYearEndDatesSummaryController().show()(FakeRequest())
       contentType(result) shouldBe Some("text/html")
@@ -204,6 +213,45 @@ class FinancialYearEndDatesSummaryControllerSpec extends TestBaseSpec {
 
         val result =
           financialYearEndDatesSummaryController(session6045.aboutTheTradingHistory, session6045.forType).submit()(
+            sessionRequest
+          )
+
+        status(result)           shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(
+          aboutthetradinghistory.routes.CheckYourAnswersAboutTheTradingHistoryController.show().url
+        )
+      }
+
+      "redirect to the next page for 6048 " in {
+        val requestWithForm = FakeRequest(POST, "/")
+          .withFormUrlEncodedBody(
+            "isFinancialYearEndDatesCorrect" -> "true"
+          )
+        val session6048     = aboutYourTradingHistory6048YesSession
+        val sessionRequest  = SessionRequest(session6048, requestWithForm)
+
+        val result =
+          financialYearEndDatesSummaryController(session6048.aboutTheTradingHistory, session6048.forType).submit()(
+            sessionRequest
+          )
+
+        status(result)           shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(
+          aboutthetradinghistory.routes.FinancialYearsController.show.url
+        )
+      }
+
+      "redirect to CYA for 6048 " in {
+        val requestWithForm = FakeRequest(POST, "/")
+          .withFormUrlEncodedBody(
+            "isFinancialYearEndDatesCorrect" -> "true",
+            "from"                           -> "CYA"
+          )
+        val session6048     = aboutYourTradingHistory6048YesSession
+        val sessionRequest  = SessionRequest(session6048, requestWithForm)
+
+        val result =
+          financialYearEndDatesSummaryController(session6048.aboutTheTradingHistory, session6048.forType).submit()(
             sessionRequest
           )
 

--- a/test/controllers/aboutthetradinghistory/FinancialYearsControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/FinancialYearsControllerSpec.scala
@@ -143,6 +143,45 @@ class FinancialYearsControllerSpec extends TestBaseSpec {
         )
       }
 
+      "redirect to the next page for 6048 " in {
+        val requestWithForm = FakeRequest(POST, "/")
+          .withFormUrlEncodedBody(
+            "isFinancialYearsCorrect" -> "true"
+          )
+        val session6048     = aboutYourTradingHistory6048YesSession
+        val sessionRequest  = SessionRequest(session6048, requestWithForm)
+
+        val result =
+          financialYearsController(session6048.aboutTheTradingHistory, session6048.forType).submit()(
+            sessionRequest
+          )
+
+        status(result)           shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(
+          aboutthetradinghistory.routes.StaticCaravansController.show().url // TODO: Income6048Controller
+        )
+      }
+
+      "redirect to CYA for 6048 " in {
+        val requestWithForm = FakeRequest(POST, "/")
+          .withFormUrlEncodedBody(
+            "isFinancialYearsCorrect" -> "true",
+            "from"                    -> "CYA"
+          )
+        val session6048     = aboutYourTradingHistory6048YesSession
+        val sessionRequest  = SessionRequest(session6048, requestWithForm)
+
+        val result =
+          financialYearsController(session6048.aboutTheTradingHistory, session6048.forType).submit()(
+            sessionRequest
+          )
+
+        status(result)           shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(
+          aboutthetradinghistory.routes.CheckYourAnswersAboutTheTradingHistoryController.show().url
+        )
+      }
+
     }
 
   }

--- a/test/controllers/aboutthetradinghistory/FinancialYearsControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/FinancialYearsControllerSpec.scala
@@ -50,6 +50,16 @@ class FinancialYearsControllerSpec extends TestBaseSpec {
       status(result) shouldBe Status.OK
     }
 
+    "return 200 for 6048" in {
+      val session6048    = aboutYourTradingHistory6048YesSession
+      val sessionRequest = SessionRequest(session6048, requestWithForm)
+
+      val result = financialYearsController(session6048.aboutTheTradingHistory, session6048.forType).show()(
+        sessionRequest
+      )
+      status(result) shouldBe Status.OK
+    }
+
     "return HTML" in {
       val result = financialYearsController().show()(FakeRequest())
       contentType(result) shouldBe Some("text/html")

--- a/test/controllers/aboutthetradinghistory/FinancialYearsControllerSpec.scala
+++ b/test/controllers/aboutthetradinghistory/FinancialYearsControllerSpec.scala
@@ -52,7 +52,7 @@ class FinancialYearsControllerSpec extends TestBaseSpec {
 
     "return 200 for 6048" in {
       val session6048    = aboutYourTradingHistory6048YesSession
-      val sessionRequest = SessionRequest(session6048, requestWithForm)
+      val sessionRequest = SessionRequest(session6048, FakeRequest())
 
       val result = financialYearsController(session6048.aboutTheTradingHistory, session6048.forType).show()(
         sessionRequest

--- a/test/utils/FakeObjects.scala
+++ b/test/utils/FakeObjects.scala
@@ -753,15 +753,20 @@ trait FakeObjects {
       aboutTheTradingHistoryPartOne = Some(prefilledTurnoverSections6048)
     )
 
-  val aboutYourTradingHistory6045CYAOtherHolidayAccommodationSession: Session      =
+  val aboutYourTradingHistory6045CYAOtherHolidayAccommodationSession: Session =
     aboutYourTradingHistory6045YesSession.copy(aboutTheTradingHistoryPartOne =
       prefilledAboutTheTradingHistoryPartOneCYA6045
     )
+
   val prefilledAboutTheTradingHistoryPartOneCYA6045: AboutTheTradingHistoryPartOne =
     prefilledTurnoverSections6045.copy(otherHolidayAccommodation =
       Some(OtherHolidayAccommodation(Some(AnswerNo), None))
     )
-  val prefilledAboutTheTradingHistoryPartOneCYA6045All                             = prefilledAboutTheTradingHistoryPartOneCYA6045.copy(
+
+  val prefilledAboutTheTradingHistoryPartOneCYA6048: AboutTheTradingHistoryPartOne =
+    prefilledTurnoverSections6048
+
+  val prefilledAboutTheTradingHistoryPartOneCYA6045All                           = prefilledAboutTheTradingHistoryPartOneCYA6045.copy(
     otherHolidayAccommodation = Some(
       OtherHolidayAccommodation(
         Some(AnswerYes),
@@ -771,7 +776,7 @@ trait FakeObjects {
       )
     )
   )
-  val aboutYourTradingHistory6045CYAOtherHolidayAccommodationSessionYes: Session   =
+  val aboutYourTradingHistory6045CYAOtherHolidayAccommodationSessionYes: Session =
     aboutYourTradingHistory6045YesSession.copy(aboutTheTradingHistoryPartOne =
       prefilledAboutTheTradingHistoryPartOneCYA6045All
     )

--- a/test/utils/FakeObjects.scala
+++ b/test/utils/FakeObjects.scala
@@ -255,7 +255,12 @@ trait FakeObjects {
   val stillConnectedDetails6045NoSession: Session             =
     baseFilled6045Session.copy(stillConnectedDetails = Some(prefilledStillConnectedDetailsNo))
 
-// Not connected sessions
+  val stillConnectedDetails6048YesSession: Session =
+    baseFilled6048Session.copy(stillConnectedDetails = Some(prefilledStillConnectedDetailsYes))
+  val stillConnectedDetails6048NoSession: Session  =
+    baseFilled6048Session.copy(stillConnectedDetails = Some(prefilledStillConnectedDetailsNo))
+
+  // Not connected sessions
   val prefilledNotConnectedYes: RemoveConnectionDetails  = RemoveConnectionDetails(
     Some(
       RemoveConnectionsDetails(
@@ -373,7 +378,8 @@ trait FakeObjects {
 
   val prefilledAboutYouAndThePropertyPartTwo6045: AboutYouAndThePropertyPartTwo =
     prefilledAboutYouAndThePropertyPartTwo.copy(propertyCurrentlyUsed = prefilledPropertyCurrentlyInUsed)
-  val prefilledPropertyCurrentlyInUsed                                          =
+
+  val prefilledPropertyCurrentlyInUsed =
     PropertyCurrentlyUsed(List("fleetCaravanPark", "chaletPark", "other"), Some("another use details"))
 
   val prefilledProvideContactDetails: ProvideContactDetails = ProvideContactDetails(
@@ -416,6 +422,9 @@ trait FakeObjects {
     stillConnectedDetails6045YesSession.copy(aboutYouAndThePropertyPartTwo =
       Some(prefilledAboutYouAndThePropertyPartTwo6045)
     )
+
+  val aboutYouAndTheProperty6048YesSession: Session =
+    stillConnectedDetails6048YesSession
 
   val aboutYouAndTheProperty6045NoSession: Session             =
     stillConnectedDetails6045NoSession.copy(aboutYouAndThePropertyPartTwo =
@@ -713,10 +722,35 @@ trait FakeObjects {
     )
   )
 
+  val prefilledTurnoverSections6048: AboutTheTradingHistoryPartOne = AboutTheTradingHistoryPartOne(
+    isFinancialYearEndDatesCorrect = true,
+    isFinancialYearsCorrect = true,
+    turnoverSections6048 = Seq(
+      TurnoverSection6048(
+        today,
+        income = 111
+      ),
+      TurnoverSection6048(
+        today.minusYears(1),
+        income = 222
+      ),
+      TurnoverSection6048(
+        today.minusYears(2),
+        income = 333
+      )
+    )
+  )
+
   val aboutYourTradingHistory6045YesSession: Session =
     aboutYouAndTheProperty6045YesSession.copy(
       aboutTheTradingHistory = Some(prefilledAboutYourTradingHistory6045),
       aboutTheTradingHistoryPartOne = Some(prefilledTurnoverSections6045)
+    )
+
+  val aboutYourTradingHistory6048YesSession: Session =
+    aboutYouAndTheProperty6048YesSession.copy(
+      aboutTheTradingHistory = Some(prefilledAboutYourTradingHistory6048),
+      aboutTheTradingHistoryPartOne = Some(prefilledTurnoverSections6048)
     )
 
   val aboutYourTradingHistory6045CYAOtherHolidayAccommodationSession: Session      =

--- a/test/utils/TestBaseSpec.scala
+++ b/test/utils/TestBaseSpec.scala
@@ -158,6 +158,15 @@ trait TestBaseSpec
       aboutTheTradingHistoryPartOne = prefilledAboutTheTradingHistoryPartOneCYA6045,
       forType = FOR6045
     )
+
+  val preFilledSession6048: WithSessionRefiner =
+    preEnrichedActionRefiner(
+      referenceNumber = "99996048004",
+      aboutTheTradingHistory = prefilledAboutYourTradingHistory6048,
+      aboutTheTradingHistoryPartOne = prefilledAboutTheTradingHistoryPartOneCYA6048,
+      forType = FOR6048
+    )
+
   def preEnrichedActionRefiner(
     referenceNumber: String = "99996010004",
     forType: ForType = FOR6010,


### PR DESCRIPTION
- Added model `TurnoverSection6048`
- Updated accounting info controllers `FinancialYearEndController`, `EditFinancialYearEndDateController`, `FinancialYearEndDatesSummaryController`, `FinancialYearsController` to use model TurnoverSection6048 for 6048
- Added page [/financial-years](https://www.qa.tax.service.gov.uk/send-trade-and-cost-information/financial-years) to 6048 Trading history flow