### PR TITLE
BST-111682 Add page 'Permanent residents'

### DIFF
--- a/app/controllers/lettingHistory/LettingHistoryExtensions.scala
+++ b/app/controllers/lettingHistory/LettingHistoryExtensions.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.lettingHistory
+
+import models.Session
+import navigation.Navigator
+import navigation.identifiers.Identifier
+import play.api.libs.json.Writes
+import play.api.mvc.{AnyContent, Call, Request}
+import repositories.SessionRepo
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+extension (repository: SessionRepo)
+  def saveOrUpdateSession(
+    session: Session
+  )(using ws: Writes[Session], hc: HeaderCarrier, ec: ExecutionContext): Future[Session] =
+    repository.saveOrUpdate(session).map(_ => session)
+
+extension (navigator: Navigator)
+  def nextCall(id: Identifier, session: Session)(using hc: HeaderCarrier, request: Request[AnyContent]): Call =
+    navigator.nextPage(id, session).apply(session)

--- a/app/controllers/lettingHistory/PermanentResidentsController.scala
+++ b/app/controllers/lettingHistory/PermanentResidentsController.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.lettingHistory
+
+import actions.WithSessionRefiner
+import controllers.FORDataCaptureController
+import form.lettingHistory.PermanentResidentsForm.theForm
+import models.Session
+import models.submissions.common.AnswersYesNo
+import models.submissions.lettingHistory.LettingHistory
+import models.submissions.lettingHistory.LettingHistory.sessionWithPermanentResidents
+import navigation.LettingHistoryNavigator
+import navigation.identifiers.PermanentResidentsPageId
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepo
+import views.html.lettingHistory.permanentResidents as PermanentResidentsView
+
+import javax.inject.{Inject, Named}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future.successful
+
+class PermanentResidentsController @Inject() (
+  mcc: MessagesControllerComponents,
+  navigator: LettingHistoryNavigator,
+  theView: PermanentResidentsView,
+  sessionRefiner: WithSessionRefiner,
+  @Named("session") repository: SessionRepo
+)(using ec: ExecutionContext)
+    extends FORDataCaptureController(mcc)
+    with I18nSupport:
+
+  def show: Action[AnyContent] = (Action andThen sessionRefiner).apply { implicit request =>
+    val freshForm = theForm
+    val staleForm =
+      for lettingHistory <- request.sessionData.lettingHistory
+      yield freshForm.fill(lettingHistory.isPermanentResidence)
+
+    Ok(theView(staleForm.getOrElse(freshForm)))
+  }
+
+  def submit: Action[AnyContent] = (Action andThen sessionRefiner).async { implicit request =>
+    continueOrSaveAsDraft[AnswersYesNo](
+      theForm,
+      theFormWithErrors => successful(BadRequest(theView(theFormWithErrors))),
+      isPermanentResidence =>
+        given Session = request.sessionData
+        for updatedSession <- repository.saveOrUpdateSession(sessionWithPermanentResidents(isPermanentResidence))
+        yield Redirect(navigator.nextCall(PermanentResidentsPageId, updatedSession))
+    )
+  }

--- a/app/form/lettingHistory/PermanentResidentsForm.scala
+++ b/app/form/lettingHistory/PermanentResidentsForm.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package form.lettingHistory
+
+import form.MappingSupport.createYesNoType
+import models.submissions.common.AnswersYesNo
+import play.api.data.Form
+import play.api.data.Forms.{mapping, single}
+
+object PermanentResidentsForm:
+  val theForm = Form[AnswersYesNo](
+    single(
+      "isPermanentResidence" -> createYesNoType("lettingHistory.isPermanentResidence.error")
+    )
+  )

--- a/app/models/SensitiveSession.scala
+++ b/app/models/SensitiveSession.scala
@@ -25,6 +25,7 @@ import models.submissions.additionalinformation.AdditionalInformation
 import models.submissions.common.SensitiveAddress
 import models.submissions.connectiontoproperty.SensitiveStillConnectedDetails
 import models.submissions.downloadFORTypeForm.DownloadPDFDetails
+import models.submissions.lettingHistory.LettingHistory
 import models.submissions.notconnected.SensitiveRemoveConnectionDetails
 import models.submissions.requestReferenceNumber.SensitiveRequestReferenceNumber
 import play.api.libs.json.{Json, OFormat}
@@ -51,7 +52,9 @@ case class SensitiveSession(
   saveAsDraftPassword: Option[String] = None,
   lastCYAPageUrl: Option[String] = None,
   requestReferenceNumberDetails: Option[SensitiveRequestReferenceNumber],
-  downloadPDFDetails: Option[DownloadPDFDetails] = None
+  downloadPDFDetails: Option[DownloadPDFDetails] = None,
+  lettingHistory: Option[LettingHistory] = None
+  // Also add more properties to both this.decryptedValue and SensitiveSession.apply methods (see below)
 ) extends Sensitive[Session] {
 
   override def decryptedValue: Session = Session(
@@ -75,7 +78,9 @@ case class SensitiveSession(
     saveAsDraftPassword,
     lastCYAPageUrl,
     requestReferenceNumberDetails.map(_.decryptedValue),
-    downloadPDFDetails
+    downloadPDFDetails,
+    lettingHistory
+    // Add more properties here ...
   )
 }
 
@@ -104,6 +109,7 @@ object SensitiveSession {
     session.saveAsDraftPassword,
     session.lastCYAPageUrl,
     session.requestReferenceNumberDetails.map(SensitiveRequestReferenceNumber(_)),
-    session.downloadPDFDetails
+    session.downloadPDFDetails,
+    session.lettingHistory
   )
 }

--- a/app/models/Session.scala
+++ b/app/models/Session.scala
@@ -26,9 +26,10 @@ import models.submissions.additionalinformation.AdditionalInformation
 import models.submissions.common.Address
 import models.submissions.connectiontoproperty.StillConnectedDetails
 import models.submissions.downloadFORTypeForm.DownloadPDFDetails
+import models.submissions.lettingHistory.LettingHistory
 import models.submissions.notconnected.RemoveConnectionDetails
 import models.submissions.requestReferenceNumber.RequestReferenceNumberDetails
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.time.LocalDate
 
@@ -54,7 +55,8 @@ case class Session(
   saveAsDraftPassword: Option[String] = None,
   lastCYAPageUrl: Option[String] = None,
   requestReferenceNumberDetails: Option[RequestReferenceNumberDetails] = None,
-  downloadPDFDetails: Option[DownloadPDFDetails] = None
+  downloadPDFDetails: Option[DownloadPDFDetails] = None,
+  lettingHistory: Option[LettingHistory] = None
   // New session properties must be also added to class `UserData` and method `toUserData`
 ) {
 
@@ -108,7 +110,8 @@ case class Session(
     aboutLeaseOrAgreementPartThree,
     aboutLeaseOrAgreementPartFour,
     requestReferenceNumberDetails,
-    downloadPDFDetails
+    downloadPDFDetails,
+    lettingHistory
   )
 
   def toSummary: Summary = Summary(

--- a/app/models/audit/UserData.scala
+++ b/app/models/audit/UserData.scala
@@ -25,6 +25,7 @@ import models.submissions.additionalinformation.AdditionalInformation
 import models.submissions.common.Address
 import models.submissions.connectiontoproperty.StillConnectedDetails
 import models.submissions.downloadFORTypeForm.DownloadPDFDetails
+import models.submissions.lettingHistory.LettingHistory
 import models.submissions.notconnected.RemoveConnectionDetails
 import models.submissions.requestReferenceNumber.RequestReferenceNumberDetails
 import play.api.libs.json.{Json, OFormat}
@@ -49,7 +50,8 @@ case class UserData(
   aboutLeaseOrAgreementPartThree: Option[AboutLeaseOrAgreementPartThree],
   aboutLeaseOrAgreementPartFour: Option[AboutLeaseOrAgreementPartFour],
   requestReferenceNumber: Option[RequestReferenceNumberDetails],
-  downloadPDFDetails: Option[DownloadPDFDetails]
+  downloadPDFDetails: Option[DownloadPDFDetails],
+  lettingHistory: Option[LettingHistory]
 )
 
 object UserData {

--- a/app/models/submissions/lettingHistory/LettingHistory.scala
+++ b/app/models/submissions/lettingHistory/LettingHistory.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.submissions.lettingHistory
+
+import models.Session
+import models.submissions.common.AnswersYesNo
+import play.api.libs.json.{Format, Json}
+
+case class LettingHistory(
+  isPermanentResidence: AnswersYesNo
+)
+
+object LettingHistory:
+
+  private def foldLettingHistory(ifEmpty: LettingHistory, copyFunc: LettingHistory => LettingHistory)(using
+    session: Session
+  ): Session =
+    session.copy(lettingHistory =
+      Some(
+        session.lettingHistory.fold(ifEmpty)(copyFunc)
+      )
+    )
+
+  def sessionWithPermanentResidents(isPermanentResidence: AnswersYesNo)(using session: Session): Session =
+    this.foldLettingHistory(
+      ifEmpty = LettingHistory(
+        isPermanentResidence = isPermanentResidence
+      ),
+      copyFunc = lh => lh.copy(isPermanentResidence = isPermanentResidence)
+    )
+
+  def isPermanentResidence(session: Session): Option[AnswersYesNo] =
+    for lettingHistory <- session.lettingHistory
+    yield lettingHistory.isPermanentResidence
+
+  given Format[LettingHistory] = Json.format

--- a/app/navigation/LettingHistoryNavigator.scala
+++ b/app/navigation/LettingHistoryNavigator.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import connectors.Audit
+import models.Session
+import models.submissions.common.{AnswerNo, AnswerYes, AnswersYesNo}
+import models.submissions.lettingHistory.LettingHistory
+import navigation.identifiers.{Identifier, PermanentResidentsPageId}
+import play.api.mvc.Call
+
+import javax.inject.Inject
+
+class LettingHistoryNavigator @Inject() (audit: Audit) extends Navigator(audit):
+
+  override val routeMap: Map[Identifier, Session => Call] = Map(
+    PermanentResidentsPageId -> { session =>
+      LettingHistory.isPermanentResidence(session) match
+        case Some(AnswerYes) =>
+          Call("GET", "/path/to/residents-details")
+        // TODO Introduce the controllers.lettingHistory.ResidentsDetailsController
+
+        case Some(AnswerNo) =>
+          Call("GET", "/path/to/completed-commercial-lettings")
+        // TODO Introduce the controllers.lettingHistory.CompletedCommercialLettingsController
+
+        case _ =>
+          // As long as this navigator gets invoked AFTER the session got copied with letting history data
+          // this case should never ever match
+          throw new RuntimeException(
+            "InvalidNavigation: session.lettingHistory.isPermanentResidence was expected to be defined"
+          )
+    }
+  )

--- a/app/navigation/identifiers/LettingHistoryIdentifiers.scala
+++ b/app/navigation/identifiers/LettingHistoryIdentifiers.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation.identifiers
+
+case object PermanentResidentsPageId extends Identifier:
+  override def toString: String = "permanentResidentsPage"

--- a/app/views/lettingHistory/permanentResidents.scala.html
+++ b/app/views/lettingHistory/permanentResidents.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import actions.SessionRequest
+@import models.pages.Summary
+@import models.submissions.common.AnswersYesNo
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, GovukRadios, GovukButton}
+@import uk.gov.hmrc.govukfrontend.views.Aliases.{RadioItem, Hint}
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+
+@this(layout: Layout, formWithCSRF: FormWithCSRF, govukRadios: GovukRadios, govukButton: GovukButton)
+
+@(theForm: Form[AnswersYesNo])(implicit request: SessionRequest[?], messages: Messages)
+
+@layout(
+    summary = Some(request.sessionData.toSummary),
+    pageHeading = messages("lettingHistory.permanentResidents.heading"),
+    backLinkUrl = controllers.routes.TaskListController.show().url + "#lettingHistory",
+    showSection = true,
+    sectionName = messages("label.section.lettingHistory"),
+) {
+
+    <p class="govuk-body">@messages("lettingHistory.permanentResidents.subheading")</p>
+
+    @formWithCSRF(action = controllers.lettingHistory.routes.PermanentResidentsController.submit) {
+        @includes.radioButtonsYesNo(
+            govukRadios,
+            theForm,
+            "isPermanentResidence",
+            "lettingHistory.isPermanentResidence.label",
+            hint = messages("lettingHistory.isPermanentResidence.hint"),
+            classes = "govuk-fieldset__legend--s",
+            isHeading = true
+        )
+        @includes.continueSaveAsDraftButtons(govukButton)
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,6 +6,7 @@
 ->          /                                                   leaseOrTenure.Routes
 ->          /                                                   tradingHistory.Routes
 ->          /                                                   youAndProperty.Routes
+->          /                                                   lettingHistory.Routes
 
 GET         /assets/*file                                       controllers.Assets.versioned(path = "/public", file: Asset)
 # Dummy start page

--- a/conf/lettingHistory.routes
+++ b/conf/lettingHistory.routes
@@ -1,0 +1,4 @@
+# lettingHistory.routes
+
+GET         /permanent-residents                                controllers.lettingHistory.PermanentResidentsController.show
+POST        /permanent-residents                                controllers.lettingHistory.PermanentResidentsController.submit

--- a/conf/messages
+++ b/conf/messages
@@ -1595,6 +1595,16 @@ error.whatIsYourRentBasedOn.required = Describe how your rent is calculated
 error.currentRentBasedOn.required = Select what your rent is based on
 error.currentRentBasedOn.maxLength = Additional information must be 500 characters or fewer
 
+
+# LETTING HISTORY 6048
+# ############################
+lettingHistory.permanentResidents.heading = Permanent residents
+lettingHistory.permanentResidents.subheading = You must declare if any part of the property is occupied by tenants or employees as their permanent residence. Include any commercial residential lettings and staff accommodation.
+lettingHistory.isPermanentResidence.label = Is any part of the property used as a permanent residence by tenants or employees?
+lettingHistory.isPermanentResidence.hint = Include any commercial residential lettings and staff accommodation.
+lettingHistory.isPermanentResidence.error= Select yes if the property is occupied as permanent residence.
+
+
 # 6010 TYPES
 ##############################
 userType.occupierTrustee = Occupier or trustee for occupier

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1558,6 +1558,16 @@ error.whatIsYourRentBasedOn.required = Describe how your rent is calculated
 error.currentRentBasedOn.required = Select what your rent is based on
 error.currentRentBasedOn.maxLength = Additional information must be 500 characters or fewer
 
+
+# LETTING HISTORY 6048
+# ############################
+lettingHistory.permanentResidents.heading = Permanent residents
+lettingHistory.permanentResidents.subheading = You must declare if any part of the property is occupied by tenants or employees as their permanent residence. Include any commercial residential lettings and staff accommodation.
+lettingHistory.isPermanentResidence.label = Is any part of the property used as a permanent residence by tenants or employees?
+lettingHistory.isPermanentResidence.hint = Include any commercial residential lettings and staff accommodation.
+lettingHistory.isPermanentResidence.error= Select yes if the property is used as permanent residence.
+
+
 # 6010 TYPES
 ##############################
 userType.occupierTrustee = Occupier or trustee for occupier

--- a/test/controllers/LoginControllerSpec.scala
+++ b/test/controllers/LoginControllerSpec.scala
@@ -248,7 +248,8 @@ class LoginControllerSpec extends TestBaseSpec {
             aboutLeaseOrAgreementPartThree = Some(prefilledAboutLeaseOrAgreementPartThree),
             aboutLeaseOrAgreementPartFour = Some(prefilledAboutLeaseOrAgreementPartFour),
             requestReferenceNumber = Some(prefilledRequestRefNumCYA),
-            None
+            downloadPDFDetails = None,
+            lettingHistory = None
           )
         )
       )(

--- a/test/controllers/lettingHistory/PermanentResidentsControllerSpec.scala
+++ b/test/controllers/lettingHistory/PermanentResidentsControllerSpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.lettingHistory
+
+import models.Session
+import models.submissions.common.{AnswerYes, AnswersYesNo}
+import models.submissions.lettingHistory.LettingHistory
+import navigation.LettingHistoryNavigator
+import org.mockito.ArgumentCaptor
+import play.api.http.MimeTypes.HTML
+import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.libs.json.Writes
+import play.api.mvc.Codec.utf_8 as UTF_8
+import play.api.test.Helpers.{charset, contentAsString, contentType, redirectLocation, status, stubMessagesControllerComponents}
+import repositories.SessionRepo
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.TestBaseSpec
+import views.html.lettingHistory.permanentResidents as PermanentResidentsView
+
+import scala.concurrent.Future.successful
+
+class PermanentResidentsControllerSpec extends TestBaseSpec:
+
+  "the PermanentResidents controller" when {
+    "the user session is fresh" should {
+      "be handling GET and reply 200 with the HTML form having unchecked radios" in new FreshSessionFixture {
+        val result  = controller.show(fakeGetRequest)
+        val content = contentAsString(result)
+        status(result)            shouldBe OK
+        contentType(result).value shouldBe HTML
+        charset(result).value     shouldBe UTF_8.charset
+        content                     should include("lettingHistory.permanentResidents.heading")
+        content                     should not include "checked"
+      }
+      "be handling POST isPermanentResident=null and reply 400 with error message" in new FreshSessionFixture {
+        val result = controller.submit(fakePostRequest)
+        status(result)        shouldBe BAD_REQUEST
+        contentAsString(result) should include("lettingHistory.isPermanentResidence.error")
+      }
+      "be handling POST isPermanentResident='yes' and reply 303 with redirect location of 'Residents Details' page" in new FreshSessionFixture {
+        val result = controller.submit(fakePostRequest.withFormUrlEncodedBody("isPermanentResidence" -> "yes"))
+        status(result)                   shouldBe SEE_OTHER
+        redirectLocation(result).value   shouldBe "/path/to/residents-details"
+        verify(repository, once).saveOrUpdate(data.capture())(any[Writes[Session]], any[HeaderCarrier])
+        isPermanentResidenceOf(data).value should beAnswerYes
+      }
+    }
+    "the user session is stale" should {
+      "be handling GET and reply 200 with the HTML form having checked radios" in new StaleSessionFixture(
+        isPermanentResidence = AnswerYes
+      ) {
+        val result = controller.show(fakeGetRequest)
+        status(result)            shouldBe OK
+        contentType(result).value shouldBe HTML
+        charset(result).value     shouldBe UTF_8.charset
+        contentAsString(result)     should include("checked")
+      }
+      "be handling POST isPermanentResident='no' and reply 303 with redirect location of 'Completed Commercial Lettings' page" in new StaleSessionFixture(
+        isPermanentResidence = AnswerYes
+      ) {
+        // Update the form with a different answer
+        val result = controller.submit(fakePostRequest.withFormUrlEncodedBody("isPermanentResidence" -> "no"))
+        status(result)                   shouldBe SEE_OTHER
+        redirectLocation(result).value   shouldBe "/path/to/completed-commercial-lettings"
+        verify(repository, once).saveOrUpdate(data.capture())(any[Writes[Session]], any[HeaderCarrier])
+        isPermanentResidenceOf(data).value should beAnswerNo
+      }
+    }
+  }
+
+  trait MockRepositoryFixture:
+    val repository = mock[SessionRepo]
+    val data       = captor[Session]
+    when(repository.saveOrUpdate(any[Session])(any[Writes[Session]], any[HeaderCarrier])).thenReturn(successful(()))
+
+  trait SessionCapturingFixture:
+    def isPermanentResidenceOf(session: ArgumentCaptor[Session]) =
+      LettingHistory.isPermanentResidence(session.getValue)
+
+  // It represents the scenario of fresh session (there's no letting history yet in session)
+  trait FreshSessionFixture extends MockRepositoryFixture with SessionCapturingFixture:
+    val controller = new PermanentResidentsController(
+      mcc = stubMessagesControllerComponents(),
+      navigator = inject[LettingHistoryNavigator],
+      theView = inject[PermanentResidentsView],
+      sessionRefiner = preEnrichedActionRefiner(
+        lettingHistory = None
+      ),
+      repository
+    )
+
+  // It represents the scenario of ongoing session (with some letting history already created)
+  trait StaleSessionFixture(isPermanentResidence: AnswersYesNo)
+      extends MockRepositoryFixture
+      with SessionCapturingFixture:
+    val controller = new PermanentResidentsController(
+      mcc = stubMessagesControllerComponents(),
+      navigator = inject[LettingHistoryNavigator],
+      theView = inject[PermanentResidentsView],
+      sessionRefiner = preEnrichedActionRefiner(
+        lettingHistory = Some(
+          LettingHistory(
+            isPermanentResidence = isPermanentResidence
+          )
+        )
+      ),
+      repository
+    )
+
+    // TODO test the case of session with letting history

--- a/test/utils/CustomMatchers.scala
+++ b/test/utils/CustomMatchers.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import models.submissions.common.{AnswerNo, AnswerYes, AnswersYesNo}
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+trait CustomMatchers:
+
+  def beAnswerYes = new AnswerYesNoMatcher(expected = AnswerYes)
+  def beAnswerNo  = new AnswerYesNoMatcher(expected = AnswerNo)
+
+  class AnswerYesNoMatcher(expected: AnswersYesNo) extends Matcher[AnswersYesNo]:
+    override def apply(actual: AnswersYesNo): MatchResult =
+      MatchResult(
+        actual == expected,
+        s"""Answer $actual was not $expected"""",
+        s"""Answer $actual was $expected""""
+      )
+
+object CustomMatchers extends CustomMatchers

--- a/test/utils/MockitoExtendedSugar.scala
+++ b/test/utils/MockitoExtendedSugar.scala
@@ -18,7 +18,7 @@ package utils
 
 import org.mockito.stubbing.{OngoingStubbing, Stubber}
 import org.mockito.verification.VerificationMode
-import org.mockito.{ArgumentMatcher, ArgumentMatchers, Mockito}
+import org.mockito.{ArgumentCaptor, ArgumentMatcher, ArgumentMatchers, Mockito}
 import org.scalatestplus.mockito.MockitoSugar
 
 /**
@@ -74,8 +74,11 @@ trait MockitoExtendedSugar extends MockitoSugar {
 
   def only: VerificationMode = Mockito.only()
 
+  def once: VerificationMode = Mockito.times(1)
+
   def times(wantedNumberOfInvocations: Int): VerificationMode = Mockito.times(wantedNumberOfInvocations)
 
   def calls(wantedNumberOfInvocations: Int): VerificationMode = Mockito.calls(wantedNumberOfInvocations)
 
+  def captor[T] = ArgumentCaptor.captor[T]()
 }

--- a/test/utils/TestBaseSpec.scala
+++ b/test/utils/TestBaseSpec.scala
@@ -28,6 +28,7 @@ import models.submissions.notconnected.RemoveConnectionDetails
 import models.ForType.*
 import models.{ForType, Session}
 import models.submissions.downloadFORTypeForm.DownloadPDFDetails
+import models.submissions.lettingHistory.LettingHistory
 import models.submissions.requestReferenceNumber.RequestReferenceNumberDetails
 import org.scalatest.{Inside, OptionValues}
 import org.scalatest.concurrent.ScalaFutures
@@ -52,6 +53,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait TestBaseSpec
     extends AnyWordSpec
     with Matchers
+    with CustomMatchers
     with FutureAwaits
     with DefaultAwaitTimeout
     with MockitoExtendedSugar
@@ -84,6 +86,8 @@ trait TestBaseSpec
   def messagesApi: MessagesApi = inject[MessagesApi]
 
   val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
+
+  val fakeGetRequest = fakeRequest
 
   val fakePostRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("POST", "/")
 
@@ -187,7 +191,8 @@ trait TestBaseSpec
       prefilledAboutLeaseOrAgreementPartFour
     ),
     requestReferenceNumberDetails: Option[RequestReferenceNumberDetails] = Some(prefilledRequestRefNumCYA),
-    downloadPDFDetails: Option[DownloadPDFDetails] = None
+    downloadPDFDetails: Option[DownloadPDFDetails] = None,
+    lettingHistory: Option[LettingHistory] = None
   ): WithSessionRefiner =
     new WithSessionRefiner(mockSessionRepository) {
 
@@ -214,7 +219,8 @@ trait TestBaseSpec
                 aboutLeaseOrAgreementPartThree = aboutLeaseOrAgreementPartThree,
                 aboutLeaseOrAgreementPartFour = aboutLeaseOrAgreementPartFour,
                 requestReferenceNumberDetails = requestReferenceNumberDetails,
-                downloadPDFDetails = downloadPDFDetails
+                downloadPDFDetails = downloadPDFDetails,
+                lettingHistory = lettingHistory
               ),
               request = request
             )


### PR DESCRIPTION
<img width="890" alt="Screenshot 2024-11-03 at 20 49 23" src="https://github.com/user-attachments/assets/e7c3ebce-3a3a-46ab-810f-b1f06654f4c0">

### A few notes

I tried to keep the same programming patterns adopted by previous Scala developers, and therefore copied many ideas from the existing code base (such as the adoption of the `SessionActionRefiner` and the `AnswerYesNo` enumerative type)

Also tried to add a few minor variants (especially for unit tests) in the hope to improve the readability of my Scala code (see `LettingHistoryExtensions.scala` and a more explicit distinction between _"fresh session"_ versus _"stale session"_).

Test report attached herein

<img width="1119" alt="Screenshot 2024-11-02 at 13 04 16" src="https://github.com/user-attachments/assets/f9f3faf6-7cc8-4607-abff-2c2738ffc088">
