### PR TITLE
Apply minor changes to accommodate Cucumber tests

### DIFF
--- a/app/controllers/lettingHistory/HasCompletedLettingsController.scala
+++ b/app/controllers/lettingHistory/HasCompletedLettingsController.scala
@@ -18,7 +18,7 @@ package controllers.lettingHistory
 
 import actions.{SessionRequest, WithSessionRefiner}
 import controllers.FORDataCaptureController
-import form.lettingHistory.CompletedLettingsForm.theForm
+import form.lettingHistory.HasCompletedLettingsForm.theForm
 import models.Session
 import models.submissions.common.AnswersYesNo
 import models.submissions.lettingHistory.LettingHistory.*
@@ -27,16 +27,16 @@ import navigation.identifiers.*
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepo
-import views.html.lettingHistory.completedLettings as CompletedLettingsView
+import views.html.lettingHistory.hasCompletedLettings as HasCompletedLettingsView
 
 import javax.inject.{Inject, Named}
 import scala.concurrent.Future.successful
 import scala.concurrent.{ExecutionContext, Future}
 
-class CompletedLettingsController @Inject (
+class HasCompletedLettingsController @Inject(
   mcc: MessagesControllerComponents,
   navigator: LettingHistoryNavigator,
-  theView: CompletedLettingsView,
+  theView: HasCompletedLettingsView,
   sessionRefiner: WithSessionRefiner,
   @Named("session") repository: SessionRepo
 )(using ec: ExecutionContext)

--- a/app/controllers/lettingHistory/HasPermanentResidentsController.scala
+++ b/app/controllers/lettingHistory/HasPermanentResidentsController.scala
@@ -18,7 +18,7 @@ package controllers.lettingHistory
 
 import actions.{SessionRequest, WithSessionRefiner}
 import controllers.FORDataCaptureController
-import form.lettingHistory.PermanentResidentsForm.theForm
+import form.lettingHistory.HasPermanentResidentsForm.theForm
 import models.Session
 import models.submissions.common.AnswersYesNo
 import models.submissions.lettingHistory.LettingHistory.*
@@ -27,16 +27,16 @@ import navigation.identifiers.PermanentResidentsPageId
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepo
-import views.html.lettingHistory.permanentResidents as PermanentResidentsView
+import views.html.lettingHistory.hasPermanentResidents as HasPermanentResidentsView
 
 import javax.inject.{Inject, Named}
 import scala.concurrent.Future.successful
 import scala.concurrent.{ExecutionContext, Future}
 
-class PermanentResidentsController @Inject() (
+class HasPermanentResidentsController @Inject()(
   mcc: MessagesControllerComponents,
   navigator: LettingHistoryNavigator,
-  theView: PermanentResidentsView,
+  theView: HasPermanentResidentsView,
   sessionRefiner: WithSessionRefiner,
   @Named("session") repository: SessionRepo
 )(using ec: ExecutionContext)

--- a/app/form/lettingHistory/HasCompletedLettingsForm.scala
+++ b/app/form/lettingHistory/HasCompletedLettingsForm.scala
@@ -21,9 +21,9 @@ import models.submissions.common.AnswersYesNo
 import play.api.data.Form
 import play.api.data.Forms.single
 
-object PermanentResidentsForm:
+object HasCompletedLettingsForm:
   val theForm = Form[AnswersYesNo](
     single(
-      "answer" -> answerYesNo(errorMessage = "lettingHistory.hasPermanentResidents.required")
+      "answer" -> answerYesNo(errorMessage = "lettingHistory.hasCompletedLettings.required")
     )
   )

--- a/app/form/lettingHistory/HasPermanentResidentsForm.scala
+++ b/app/form/lettingHistory/HasPermanentResidentsForm.scala
@@ -21,9 +21,9 @@ import models.submissions.common.AnswersYesNo
 import play.api.data.Form
 import play.api.data.Forms.single
 
-object CompletedLettingsForm:
+object HasPermanentResidentsForm:
   val theForm = Form[AnswersYesNo](
     single(
-      "answer" -> answerYesNo(errorMessage = "lettingHistory.hasCompletedLettings.required")
+      "answer" -> answerYesNo(errorMessage = "lettingHistory.hasPermanentResidents.required")
     )
   )

--- a/app/navigation/LettingHistoryNavigator.scala
+++ b/app/navigation/LettingHistoryNavigator.scala
@@ -20,6 +20,7 @@ import actions.SessionRequest
 import connectors.Audit
 import controllers.lettingHistory.{RentalPeriodSupport, routes}
 import models.Session
+import models.submissions.lettingHistory.LettingHistory
 import models.submissions.lettingHistory.LettingHistory.*
 import navigation.identifiers.*
 import play.api.mvc.Results.Redirect
@@ -43,7 +44,7 @@ class LettingHistoryNavigator @Inject() (audit: Audit) extends Navigator(audit) 
       Some(controllers.routes.TaskListController.show().withFragment("lettingHistory"))
     },
     ResidentDetailPageId           -> { (_, _) =>
-      Some(routes.PermanentResidentsController.show)
+      Some(routes.HasPermanentResidentsController.show)
     },
     ResidentListPageId             -> { (currentSession, _) =>
       for size <- Some(permanentResidents(currentSession).size)
@@ -53,7 +54,7 @@ class LettingHistoryNavigator @Inject() (audit: Audit) extends Navigator(audit) 
           if size < MaxNumberOfPermanentResidents
           then routes.ResidentDetailController.show(index = None)
           else routes.MaxNumberReachedController.show(kind = "permanentResidents")
-        else routes.PermanentResidentsController.show
+        else routes.HasPermanentResidentsController.show
     },
     MaxNumberReachedPageId         -> { (_, navigationData) =>
       for kind <- navigationData.get("kind")
@@ -69,10 +70,10 @@ class LettingHistoryNavigator @Inject() (audit: Audit) extends Navigator(audit) 
         else
           hasPermanentResidents(currentSession) match
             case Some(true) => routes.ResidentDetailController.show(index = None)
-            case _          => routes.PermanentResidentsController.show
+            case _          => routes.HasPermanentResidentsController.show
     },
     OccupierDetailPageId           -> { (_, _) =>
-      Some(routes.CompletedLettingsController.show)
+      Some(routes.HasCompletedLettingsController.show)
     },
     RentalPeriodPageId             -> { (_, navigationData) =>
       Some(routes.OccupierDetailController.show(navigationData.get("index").map(_.toInt)))
@@ -85,21 +86,21 @@ class LettingHistoryNavigator @Inject() (audit: Audit) extends Navigator(audit) 
           if size < MaxNumberOfCompletedLettings
           then routes.OccupierDetailController.show(index = None)
           else routes.MaxNumberReachedController.show(kind = "temporaryOccupiers")
-        else routes.CompletedLettingsController.show
+        else routes.HasCompletedLettingsController.show
     },
     HowManyNightsPageId            -> { (currentSession, _) =>
       for doesHaveCompletedLettings <- hasCompletedLettings(currentSession)
       yield
         if doesHaveCompletedLettings
         then routes.OccupierListController.show
-        else routes.CompletedLettingsController.show
+        else routes.HasCompletedLettingsController.show
     },
     // TODO IntendedLettingNightsPageId ... either CompletedLettings or OccupierList
-    AdvertisingOnlinePageId        -> { (_, _) =>
+    AdvertisingOnlinePageId -> { (_, _) =>
       Some(controllers.routes.TaskListController.show())
     },
     AdvertisingOnlineDetailsPageId -> { (_, _) =>
-      Some(routes.AdvertisingOnlineController.show)
+    Some(routes.AdvertisingOnlineController.show)
     }
   )
 
@@ -136,7 +137,7 @@ class LettingHistoryNavigator @Inject() (audit: Audit) extends Navigator(audit) 
           if permanentResidents(updatedSession).size < MaxNumberOfPermanentResidents
           then routes.ResidentDetailController.show(index = None)
           else routes.ResidentListController.show
-        else routes.CompletedLettingsController.show
+        else routes.HasCompletedLettingsController.show
     },
     ResidentDetailPageId           -> { (_, _) =>
       Some(routes.ResidentListController.show)
@@ -153,12 +154,12 @@ class LettingHistoryNavigator @Inject() (audit: Audit) extends Navigator(audit) 
           if permanentResidents(updatedSession).size < MaxNumberOfPermanentResidents
           then routes.ResidentDetailController.show(index = None)
           else routes.MaxNumberReachedController.show(kind = "permanentResidents")
-        else routes.CompletedLettingsController.show
+        else routes.HasCompletedLettingsController.show
     },
     MaxNumberReachedPageId         -> { (_, navigationData) =>
       for kind <- Some(navigationData("kind"))
       yield
-        if kind == "permanentResidents" then routes.CompletedLettingsController.show
+        if kind == "permanentResidents" then routes.HasCompletedLettingsController.show
         else if kind == "temporaryOccupiers" then routes.HowManyNightsController.show
         else controllers.routes.TaskListController.show().withFragment("lettingHistory")
     },

--- a/app/views/includes/radioButtonsYesNo.scala.html
+++ b/app/views/includes/radioButtonsYesNo.scala.html
@@ -32,12 +32,13 @@
         classes: String = "",
         hint: String = "",
         isHeading: Boolean = false,
-        legend: Option[String] = None)(implicit messages: Messages)
+        legend: Option[String] = None,
+        idPrefix: Option[String] = None)(implicit messages: Messages)
 
 @govukRadios(
   Radios(
     name = name,
-    idPrefix = Option(s"$name"),
+    idPrefix = idPrefix.fold(Option(s"$name"))(identity(_)),
     items = Seq(
       "yes" -> messages(yesLabel),
       "no" -> messages(noLabel)

--- a/app/views/lettingHistory/advertisingOnline.scala.html
+++ b/app/views/lettingHistory/advertisingOnline.scala.html
@@ -40,8 +40,9 @@
         @includes.radioButtonsYesNo(
             govukRadios,
             theForm,
-            "advertisingOnline",
-            "lettingHistory.advertisingOnline.heading",
+            idPrefix = "lettingHistoryAdvertisingOnline",
+            name = "advertisingOnline",
+            legendKey = "lettingHistory.advertisingOnline.heading",
             classes = "govuk-fieldset__legend--l",
             isHeading = true
         )

--- a/app/views/lettingHistory/hasCompletedLettings.scala.html
+++ b/app/views/lettingHistory/hasCompletedLettings.scala.html
@@ -45,10 +45,11 @@
         <li>@messages("lettingHistory.completedLettings.paragraph.3.point.2")</li>
     </ul>
 
-    @formWithCSRF(action = routes.CompletedLettingsController.submit) {
+    @formWithCSRF(action = routes.HasCompletedLettingsController.submit) {
         @includes.radioButtonsYesNo(
             govukRadios,
             theForm,
+            idPrefix = "lettingHistoryHasCompletedLettings",
             name = "answer",
             legendKey = "", // see legend instead
             classes = "govuk-fieldset__legend--s",

--- a/app/views/lettingHistory/hasPermanentResidents.scala.html
+++ b/app/views/lettingHistory/hasPermanentResidents.scala.html
@@ -34,10 +34,11 @@
 
     <p class="govuk-body">@messages("lettingHistory.permanentResidents.subheading")</p>
 
-    @formWithCSRF(action = controllers.lettingHistory.routes.PermanentResidentsController.submit) {
+    @formWithCSRF(action = controllers.lettingHistory.routes.HasPermanentResidentsController.submit) {
         @includes.radioButtonsYesNo(
             govukRadios,
             theForm,
+            idPrefix = "lettingHistoryHasPermanentResidents",
             name = "answer",
             legendKey = "lettingHistory.hasPermanentResidents.legend",
             hint = messages("lettingHistory.hasPermanentResidents.hint"),

--- a/app/views/lettingHistory/occupierList.scala.html
+++ b/app/views/lettingHistory/occupierList.scala.html
@@ -91,6 +91,7 @@
         @includes.radioButtonsYesNo(
             govukRadios,
             theForm,
+            idPrefix = "lettingHistoryOccupierList",
             name = "answer",
             legend = messages(
                 "lettingHistory.occupiersList.hadMoreOccupiers.label",

--- a/app/views/lettingHistory/residentList.scala.html
+++ b/app/views/lettingHistory/residentList.scala.html
@@ -78,6 +78,7 @@
         @includes.radioButtonsYesNo(
             govukRadios,
             theForm,
+            idPrefix = "lettingHistoryResidentList",
             name = "answer",
             legendKey = "lettingHistory.residentList.hasMoreResidents.label",
             classes = "govuk-fieldset__legend--s",

--- a/conf/lettingHistory.routes
+++ b/conf/lettingHistory.routes
@@ -1,39 +1,39 @@
 # lettingHistory.routes
 
-GET         /letting-history/permanent-residents                controllers.lettingHistory.PermanentResidentsController.show
-POST        /letting-history/permanent-residents                controllers.lettingHistory.PermanentResidentsController.submit
+GET         /letting-history-has-permanent-residents            controllers.lettingHistory.HasPermanentResidentsController.show
+POST        /letting-history-has-permanent-residents            controllers.lettingHistory.HasPermanentResidentsController.submit
 
-GET         /letting-history/resident-detail                    controllers.lettingHistory.ResidentDetailController.show(index: Option[Int] ?= None)
-POST        /letting-history/resident-detail                    controllers.lettingHistory.ResidentDetailController.submit
+GET         /letting-history-resident-detail                    controllers.lettingHistory.ResidentDetailController.show(index: Option[Int] ?= None)
+POST        /letting-history-resident-detail                    controllers.lettingHistory.ResidentDetailController.submit
 
-GET         /letting-history/resident-list                      controllers.lettingHistory.ResidentListController.show
-GET         /letting-history/resident-remove                    controllers.lettingHistory.ResidentListController.remove(index: Int)
-POST        /letting-history/resident-remove                    controllers.lettingHistory.ResidentListController.performRemove(index: Int)
-POST        /letting-history/resident-list                      controllers.lettingHistory.ResidentListController.submit
-
-GET         /letting-history/completed-lettings                 controllers.lettingHistory.CompletedLettingsController.show
-POST        /letting-history/completed-lettings                 controllers.lettingHistory.CompletedLettingsController.submit
+GET         /letting-history-resident-list                      controllers.lettingHistory.ResidentListController.show
+GET         /letting-history-resident-remove                    controllers.lettingHistory.ResidentListController.remove(index: Int)
+POST        /letting-history-resident-remove                    controllers.lettingHistory.ResidentListController.performRemove(index: Int)
+POST        /letting-history-resident-list                      controllers.lettingHistory.ResidentListController.submit
 
 
-GET         /letting-history/occupier-detail                    controllers.lettingHistory.OccupierDetailController.show(index: Option[Int] ?= None)
-POST        /letting-history/occupier-detail                    controllers.lettingHistory.OccupierDetailController.submit
+GET         /letting-history-has-completed-lettings             controllers.lettingHistory.HasCompletedLettingsController.show
+POST        /letting-history-has-completed-lettings             controllers.lettingHistory.HasCompletedLettingsController.submit
 
-GET         /letting-history/rental-period                      controllers.lettingHistory.RentalPeriodController.show(index: Option[Int] ?= None)
-POST        /letting-history/rental-period                      controllers.lettingHistory.RentalPeriodController.submit(index: Option[Int] ?= None)
+GET         /letting-history-occupier-detail                    controllers.lettingHistory.OccupierDetailController.show(index: Option[Int] ?= None)
+POST        /letting-history-occupier-detail                    controllers.lettingHistory.OccupierDetailController.submit
 
-GET         /letting-history/occupier-list                      controllers.lettingHistory.OccupierListController.show
-GET         /letting-history/occupier-remove                    controllers.lettingHistory.OccupierListController.remove(index: Int)
-POST        /letting-history/occupier-remove                    controllers.lettingHistory.OccupierListController.performRemove(index: Int)
-POST        /letting-history/occupier-list                      controllers.lettingHistory.OccupierListController.submit
+GET         /letting-history-rental-period                      controllers.lettingHistory.RentalPeriodController.show(index: Option[Int] ?= None)
+POST        /letting-history-rental-period                      controllers.lettingHistory.RentalPeriodController.submit(index: Option[Int] ?= None)
 
-GET         /letting-history/advertising-online                 controllers.lettingHistory.AdvertisingOnlineController.show
-POST        /letting-history/advertising-online                 controllers.lettingHistory.AdvertisingOnlineController.submit
+GET         /letting-history-occupier-list                      controllers.lettingHistory.OccupierListController.show
+GET         /letting-history-occupier-remove                    controllers.lettingHistory.OccupierListController.remove(index: Int)
+POST        /letting-history-occupier-remove                    controllers.lettingHistory.OccupierListController.performRemove(index: Int)
+POST        /letting-history-occupier-list                      controllers.lettingHistory.OccupierListController.submit
 
-GET         /letting-history/advertising-online-details         controllers.lettingHistory.AdvertisingOnlineDetailsController.show(index: Option[Int] ?= None)
-POST        /letting-history/advertising-online-details         controllers.lettingHistory.AdvertisingOnlineDetailsController.submit
+GET         /letting-history-max-number-reached                 controllers.lettingHistory.MaxNumberReachedController.show(kind: String)
+POST        /letting-history-max-number-reached                 controllers.lettingHistory.MaxNumberReachedController.submit(kind: String)
 
-GET         /letting-history/max-number-reached                 controllers.lettingHistory.MaxNumberReachedController.show(kind: String)
-POST        /letting-history/max-number-reached                 controllers.lettingHistory.MaxNumberReachedController.submit(kind: String)
+GET         /letting-history-how-many-nights                    controllers.lettingHistory.HowManyNightsController.show
+POST        /letting-history-how-many-nights                    controllers.lettingHistory.HowManyNightsController.submit
 
-GET         /letting-history/how-many-nights                    controllers.lettingHistory.HowManyNightsController.show
-POST        /letting-history/how-many-nights                    controllers.lettingHistory.HowManyNightsController.submit
+GET         /letting-history-advertising-online                 controllers.lettingHistory.AdvertisingOnlineController.show
+POST        /letting-history-advertising-online                 controllers.lettingHistory.AdvertisingOnlineController.submit
+
+GET         /letting-history-advertising-online-details         controllers.lettingHistory.AdvertisingOnlineDetailsController.show(index: Option[Int] ?= None)
+POST        /letting-history-advertising-online-details         controllers.lettingHistory.AdvertisingOnlineDetailsController.submit

--- a/test/controllers/lettingHistory/HasPermanentResidentsControllerSpec.scala
+++ b/test/controllers/lettingHistory/HasPermanentResidentsControllerSpec.scala
@@ -26,113 +26,105 @@ import play.api.libs.json.Writes
 import play.api.mvc.Codec.utf_8 as UTF_8
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
-import views.html.lettingHistory.completedLettings as CompletedLettingsView
+import views.html.lettingHistory.hasPermanentResidents as HasPermanentResidentsView
 
-class CompletedLettingsControllerSpec extends LettingHistoryControllerSpec:
+class HasPermanentResidentsControllerSpec extends LettingHistoryControllerSpec:
 
-  "the CompletedLettings controller" when {
+  "the PermanentResidents controller" when {
     "the user has not provided any answer yet" should {
-      "be handling GET by replying 200 with the HTML form having unchecked radios" in new ControllerFixture {
+      "be handling GET and reply 200 with the HTML form having unchecked radios" in new ControllerFixture {
         val result = controller.show(fakeGetRequest)
         status(result)            shouldBe OK
         contentType(result).value shouldBe HTML
         charset(result).value     shouldBe UTF_8.charset
         val page = contentAsJsoup(result)
-        page.heading        shouldBe "lettingHistory.completedLettings.heading"
-        page.backLink       shouldBe routes.PermanentResidentsController.show.url
+        page.heading        shouldBe "lettingHistory.permanentResidents.heading"
+        page.backLink       shouldBe controllers.routes.TaskListController.show().withFragment("lettingHistory").toString
         page.radios("answer") should haveNoneChecked
       }
       "be handling invalid POST by replying 400 with error message" in new ControllerFixture {
         val result = controller.submit(
           fakePostRequest.withFormUrlEncodedBody(
-            "answer" -> ""
+            "answer" -> "" // missing
           )
         )
         status(result) shouldBe BAD_REQUEST
         val page   = contentAsJsoup(result)
-        page.error("answer") shouldBe "lettingHistory.hasCompletedLettings.required"
+        page.error("answer") shouldBe "lettingHistory.hasPermanentResidents.required"
       }
-      "be handling POST answer='yes' by replying 303 redirect to 'Occupier Detail' page" in new ControllerFixture {
+      "be handling POST answer='yes' by replying 303 redirect to the 'Residents Details' page" in new ControllerFixture {
         val result = controller.submit(
           fakePostRequest.withFormUrlEncodedBody(
             "answer" -> "yes"
           )
         )
         status(result) shouldBe SEE_OTHER
-        redirectLocation(result).value   shouldBe routes.OccupierDetailController.show(index = None).url
+        redirectLocation(result).value    shouldBe routes.ResidentDetailController.show().url
         verify(repository, once).saveOrUpdate(data.capture())(any[Writes[Session]], any[HeaderCarrier])
-        hasCompletedLettings(data).value shouldBe true
+        hasPermanentResidents(data).value shouldBe true
       }
     }
-    "the user has already provided an answer"  should {
-      "regardless of the given number of occupiers"          should {
-        "be handling GET by replying 200 with the HTML form having checked radios" in new ControllerFixture(
-          permanentResidents = twoResidents,
-          hasCompletedLettings = Some(true)
+    "the user has already answered"            should {
+      "regardless of the given number of residents"          should {
+        "be handling GET and reply 200 with the HTML form having checked radios" in new ControllerFixture(
+          oneResident
         ) {
           val result = controller.show(fakeGetRequest)
           status(result)            shouldBe OK
           contentType(result).value shouldBe HTML
           charset(result).value     shouldBe UTF_8.charset
           val page = contentAsJsoup(result)
-          page.backLink          shouldBe routes.ResidentListController.show.url
-          page.radios("answer")    should haveChecked(value = "yes")
-          page.radios("answer") shouldNot haveChecked(value = "no")
+          page.radios("answer")    should haveChecked("yes")
+          page.radios("answer") shouldNot haveChecked("no")
         }
-        "be handling POST answer='yes' by replying 303 redirect to the 'Occupier Detail' page" in new ControllerFixture(
-          hasCompletedLettings = Some(true)
+        "be handling POST answer='yes' by replying 303 redirect to the 'Resident Detail' page" in new ControllerFixture(
+          oneResident
         ) {
           val result = controller.submit(fakePostRequest.withFormUrlEncodedBody("answer" -> "yes"))
-          status(result)                   shouldBe SEE_OTHER
-          redirectLocation(result).value   shouldBe routes.OccupierDetailController.show(index = None).url
+          status(result)                    shouldBe SEE_OTHER
+          redirectLocation(result).value    shouldBe routes.ResidentDetailController.show().url
           verify(repository, once).saveOrUpdate(data.capture())(any[Writes[Session]], any[HeaderCarrier])
-          hasCompletedLettings(data).value shouldBe true
+          hasPermanentResidents(data).value shouldBe true
         }
-        "be handling POST answer='no' by replying 303 redirect to the 'Letting intention' page" in new ControllerFixture(
-          hasCompletedLettings = Some(true)
+        "be handling POST answer='no' by replying 303 redirect to the 'Commercial Lettings' page" in new ControllerFixture(
+          oneResident
         ) {
           // Answering 'no' will clear out all residents details
-          val result = controller.submit(
-            fakePostRequest.withFormUrlEncodedBody(
-              "answer" -> "no"
-            )
-          )
-          status(result) shouldBe SEE_OTHER
-          redirectLocation(result).value   shouldBe routes.HowManyNightsController.show.url
+          val result = controller.submit(fakePostRequest.withFormUrlEncodedBody("answer" -> "no"))
+          status(result)                    shouldBe SEE_OTHER
+          redirectLocation(result).value    shouldBe routes.HasCompletedLettingsController.show.url
           verify(repository, once).saveOrUpdate(data.capture())(any[Writes[Session]], any[HeaderCarrier])
-          hasCompletedLettings(data).value shouldBe false
-          completedLettings(data)          shouldBe Nil
+          hasPermanentResidents(data).value shouldBe false
+          permanentResidents(data)          shouldBe Nil
         }
       }
       "and the maximum number of residents has been reached" should {
-        "be handling POST hasCompletedLettings='yes' and reply 303 redirect to the 'Occupiers List' page" in new ControllerFixture(
-          hasCompletedLettings = Some(true)
+        "be handling POST answer='yes' by replying 303 redirect to the 'Resident List' page" in new ControllerFixture(
+          fiveResidents
         ) {
-          pending
           val result = controller.submit(fakePostRequest.withFormUrlEncodedBody("answer" -> "yes"))
-          status(result)                   shouldBe SEE_OTHER
-          redirectLocation(result).value   shouldBe routes.OccupierListController.show.url
+          status(result)                    shouldBe SEE_OTHER
+          redirectLocation(result).value    shouldBe routes.ResidentListController.show.url
           verify(repository, once).saveOrUpdate(data.capture())(any[Writes[Session]], any[HeaderCarrier])
-          hasCompletedLettings(data).value shouldBe true
-          completedLettings(data)            should have size 5
+          hasPermanentResidents(data).value shouldBe true
+          permanentResidents(data)            should have size 5
         }
       }
     }
   }
 
-  trait ControllerFixture(permanentResidents: List[ResidentDetail] = Nil, hasCompletedLettings: Option[Boolean] = None)
+  trait ControllerFixture(permanentResidents: List[ResidentDetail] = Nil)
       extends MockRepositoryFixture
       with SessionCapturingFixture:
-    val controller = new CompletedLettingsController(
+    val controller = new HasPermanentResidentsController(
       mcc = stubMessagesControllerComponents(),
       navigator = inject[LettingHistoryNavigator],
-      theView = inject[CompletedLettingsView],
+      theView = inject[HasPermanentResidentsView],
       sessionRefiner = preEnrichedActionRefiner(
         lettingHistory = Some(
           LettingHistory(
             hasPermanentResidents = Some(permanentResidents.nonEmpty),
-            permanentResidents = permanentResidents,
-            hasCompletedLettings = hasCompletedLettings
+            permanentResidents = permanentResidents
           )
         )
       ),

--- a/test/controllers/lettingHistory/HowManyNightsControllerSpec.scala
+++ b/test/controllers/lettingHistory/HowManyNightsControllerSpec.scala
@@ -41,7 +41,7 @@ class HowManyNightsControllerSpec extends LettingHistoryControllerSpec:
         charset(result).value     shouldBe UTF_8.charset
         val page = contentAsJsoup(result)
         page.heading       shouldBe "lettingHistory.intendedLettings.heading"
-        page.backLink      shouldBe routes.CompletedLettingsController.show.url
+        page.backLink      shouldBe routes.HasCompletedLettingsController.show.url
         page.input("nights") should beEmpty
       }
       "be handling good POST by replying 303 redirect to the 'Yearly availability' page" in new ControllerFixture(

--- a/test/controllers/lettingHistory/MaxNumberReachedControllerSpec.scala
+++ b/test/controllers/lettingHistory/MaxNumberReachedControllerSpec.scala
@@ -86,7 +86,7 @@ class MaxNumberReachedControllerSpec extends LettingHistoryControllerSpec:
               .withFormUrlEncodedBody("understood" -> "false")
           )
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result).value            shouldBe routes.CompletedLettingsController.show.url
+          redirectLocation(result).value            shouldBe routes.HasCompletedLettingsController.show.url
           verify(repository, once).saveOrUpdate(data.capture())(any[Writes[Session]], any[HeaderCarrier])
           mayHaveMorePermanentResidents(data).value shouldBe false
         }

--- a/test/controllers/lettingHistory/OccupierDetailControllerSpec.scala
+++ b/test/controllers/lettingHistory/OccupierDetailControllerSpec.scala
@@ -39,7 +39,7 @@ class OccupierDetailControllerSpec extends LettingHistoryControllerSpec:
         charset(result).value     shouldBe UTF_8.charset
         val page = contentAsJsoup(result)
         page.heading                 shouldBe "lettingHistory.occupierDetail.heading"
-        page.backLink                shouldBe routes.CompletedLettingsController.show.url
+        page.backLink                shouldBe routes.HasCompletedLettingsController.show.url
         page.input("name")             should beEmpty
         page.input("address.line1")    should beEmpty
         page.input("address.town")     should beEmpty

--- a/test/controllers/lettingHistory/OccupierListControllerSpec.scala
+++ b/test/controllers/lettingHistory/OccupierListControllerSpec.scala
@@ -40,7 +40,7 @@ class OccupierListControllerSpec extends LettingHistoryControllerSpec:
         charset(result).value     shouldBe UTF_8.charset
         val page = contentAsJsoup(result)
         page.heading     shouldBe "lettingHistory.occupierList.heading.plural"
-        page.backLink    shouldBe routes.CompletedLettingsController.show.url
+        page.backLink    shouldBe routes.HasCompletedLettingsController.show.url
         page.summaryList shouldBe empty
       }
       "be handling GET /remove?index=0 by replying redirect to the 'Occupiers List' page" in new ControllerFixture {

--- a/test/controllers/lettingHistory/ResidentDetailControllerSpec.scala
+++ b/test/controllers/lettingHistory/ResidentDetailControllerSpec.scala
@@ -39,7 +39,7 @@ class ResidentDetailControllerSpec extends LettingHistoryControllerSpec:
         charset(result).value     shouldBe UTF_8.charset
         val page = contentAsJsoup(result)
         page.heading           shouldBe "lettingHistory.residentDetail.heading"
-        page.backLink          shouldBe routes.PermanentResidentsController.show.url
+        page.backLink          shouldBe routes.HasPermanentResidentsController.show.url
         page.input("name")       should beEmpty
         page.textarea("address") should beEmpty
       }

--- a/test/controllers/lettingHistory/ResidentListControllerSpec.scala
+++ b/test/controllers/lettingHistory/ResidentListControllerSpec.scala
@@ -40,7 +40,7 @@ class ResidentListControllerSpec extends LettingHistoryControllerSpec:
         charset(result).value     shouldBe UTF_8.charset
         val page = contentAsJsoup(result)
         page.heading     shouldBe "lettingHistory.residentList.heading.plural"
-        page.backLink    shouldBe routes.PermanentResidentsController.show.url
+        page.backLink    shouldBe routes.HasPermanentResidentsController.show.url
         page.summaryList shouldBe empty
       }
       "be handling GET /remove?index=0 by replying redirect to the 'Resident List' page" in new ControllerFixture {
@@ -154,7 +154,7 @@ class ResidentListControllerSpec extends LettingHistoryControllerSpec:
       "be handling POST /list?hasMoreResidents=no by replying redirect to the 'Commercial Lettings' page" in new ControllerFixture {
         val result = controller.submit(fakePostRequest.withFormUrlEncodedBody("answer" -> "no"))
         status(result)                 shouldBe SEE_OTHER
-        redirectLocation(result).value shouldBe routes.CompletedLettingsController.show.url
+        redirectLocation(result).value shouldBe routes.HasCompletedLettingsController.show.url
       }
     }
   }

--- a/test/form/lettingHistory/HasCompletedLettingsFormSpec.scala
+++ b/test/form/lettingHistory/HasCompletedLettingsFormSpec.scala
@@ -16,10 +16,10 @@
 
 package form.lettingHistory
 
+import form.lettingHistory.HasCompletedLettingsForm.theForm
 import models.submissions.common.AnswerYes
-import form.lettingHistory.PermanentResidentsForm.theForm
 
-class PermanentResidentFormSpec extends FormSpec:
+class HasCompletedLettingsFormSpec extends FormSpec:
 
   it should "bind data as expected" in {
     val data  = Map(
@@ -50,5 +50,5 @@ class PermanentResidentFormSpec extends FormSpec:
     bound
       .error("answer")
       .value
-      .message mustBe "lettingHistory.hasPermanentResidents.required"
+      .message mustBe "lettingHistory.hasCompletedLettings.required"
   }

--- a/test/form/lettingHistory/HasPermanentResidentFormSpec.scala
+++ b/test/form/lettingHistory/HasPermanentResidentFormSpec.scala
@@ -16,10 +16,10 @@
 
 package form.lettingHistory
 
-import form.lettingHistory.CompletedLettingsForm.theForm
 import models.submissions.common.AnswerYes
+import form.lettingHistory.HasPermanentResidentsForm.theForm
 
-class CompletedLettingsFormSpec extends FormSpec:
+class HasPermanentResidentFormSpec extends FormSpec:
 
   it should "bind data as expected" in {
     val data  = Map(
@@ -50,5 +50,5 @@ class CompletedLettingsFormSpec extends FormSpec:
     bound
       .error("answer")
       .value
-      .message mustBe "lettingHistory.hasCompletedLettings.required"
+      .message mustBe "lettingHistory.hasPermanentResidents.required"
   }


### PR DESCRIPTION
Make routes having just 1 fragment after the base URL. 
Adopt conventional HTML identifier for radio buttons.