### PR TITLE
BST-131249 Fix regression on the Address JSON serdes

### DIFF
--- a/test/models/submissions/AddressMappingSpec.scala
+++ b/test/models/submissions/AddressMappingSpec.scala
@@ -22,21 +22,29 @@ import utils.TestBaseSpec
 
 class AddressMappingSpec extends TestBaseSpec {
 
-  val json2 =
-    """{"buildingNameNumber":"Some House","street1":"Some Street","town":"Some City","county":"Some County","postcode":"AA11 1AA"}"""
-  val data2 = Address("Some House", Some("Some Street"), "Some City", Some("Some County"), "AA11 1AA")
+  val toBeDeserialized = """{"buildingNameNumber":"Some House","street1":"Some Street","street2":"Some City","county":"Some County","postcode":"AA11 1AA"}"""
+  val expected = Address(
+    buildingNameNumber = "Some House",
+    street1 = Some("Some Street"),
+    town = "Some City",
+    county = Some("Some County"),
+    postcode = "AA11 1AA"
+  )
 
   def toJson(data: Address): String = {
     val json = Json.toJson(data).toString
     json
   }
 
-  def fromJson(json: String): JsResult[Address] =
-    Json.fromJson[Address](Json.parse(json))
+  def fromJson(json: String): JsResult[Address] = {
+    val parsed = Json.parse(json)
+    Json.fromJson[Address](parsed)
+  }
 
   "Address with a fully filled in address" should {
     "create a fully filled Address" in {
-      fromJson(json2) should be(JsSuccess(data2))
+      val actual = fromJson(toBeDeserialized)
+      actual should be(JsSuccess(expected))
     }
   }
 

--- a/test/models/submissions/RequestReferenceNumberSubmissionSpec.scala
+++ b/test/models/submissions/RequestReferenceNumberSubmissionSpec.scala
@@ -52,7 +52,7 @@ class RequestReferenceNumberSubmissionSpec extends AnyFlatSpec with should.Match
     )
 
     val jsonString =
-      """{"businessTradingName":"BusinessTradingName","fullName":"Full Name","id":"12345","createdAt":"1970-01-21T04:48:46.680Z","address":{"postcode":"AN12 3YZ","street1":"Main Street","county":"Bristol","buildingNameNumber":"123","town":"Bristol"},"contactDetails":{"phone":"07711122233345","email":"test@email.co.uk"},"lang":"en"}"""
+      """{"businessTradingName":"BusinessTradingName","fullName":"Full Name","id":"12345","createdAt":"1970-01-21T04:48:46.680Z","address":{"buildingNameNumber":"123","street1":"Main Street","street2":"Bristol","county":"Bristol","postcode":"AN12 3YZ"},"contactDetails":{"phone":"07711122233345","email":"test@email.co.uk"},"lang":"en"}"""
 
     val json = Json.toJson(requestReferenceNumberSubmissionModel)
     json.as[RequestReferenceNumberSubmission] shouldBe requestReferenceNumberSubmissionModel


### PR DESCRIPTION
This commit is intended to fix a regression introduced by merging BST-131249
The regression was due to the attempt of reusing the `common.Address` model
wherever possible and reduce code repetitions in the frontend.

The major change is renaming of the `common.Address.street2` property to become
`common.Address.town`. Unfortunately the backend application could not be updated
accordingly, and this commit is adopting custom Play JSON Readers/Writer to cope
with the name mismatch.

There exist another merge request, completely alternative and mutually exclusive to this
merge request:

https://github.com/hmrc/tenure-cost-and-trade-records/pull/231

which, while safe to apply for development and testing environments, may be considered
too much disruptive for the production environment.

Take your time before deciding which of the two alternative fixes is best to apply.